### PR TITLE
Increase HPACK dynamic table size from 4KB to 16KB for HTTP/2

### DIFF
--- a/sdk/cosmos/azure-cosmos/src/main/java/com/azure/cosmos/implementation/http/ReactorNettyClient.java
+++ b/sdk/cosmos/azure-cosmos/src/main/java/com/azure/cosmos/implementation/http/ReactorNettyClient.java
@@ -149,6 +149,7 @@ public class ReactorNettyClient implements HttpClient {
                         )))
                 .protocol(HttpProtocol.H2, HttpProtocol.HTTP11)
                 .http2Settings(settings -> settings
+                    .headerTableSize(16384)          // 16KB HPACK dynamic table (up from default 4KB) to fit ~13KB of indexable Cosmos response headers and reduce table churn
                     .initialWindowSize(1024 * 1024) // 1MB initial window size
                     .maxFrameSize(64 * 1024)        // 64KB max frame size
                     .maxConcurrentStreams(http2CfgAccessor.getEffectiveMaxConcurrentStreams(http2Cfg))  // Increased from default 30


### PR DESCRIPTION
HPACK diagnostics revealed Cosmos responses have ~13KB of indexable headers, but the default 4KB table can only hold ~30%, causing constant table churn. 7 high-cardinality response headers (x-ms-activity-id, etag, date, etc.) evict stable headers that would otherwise benefit from dynamic indexing.

Increasing headerTableSize to 16KB (advertised to server via SETTINGS frame) allows more response headers to be indexed, reducing HPACK decode CPU and improving compression (~683 bytes/response savings when table works correctly).