### PR TITLE
Cosmos: Reactor chain Phase 1 — remove redundant operator and allocation

### DIFF
--- a/sdk/cosmos/azure-cosmos/src/main/java/com/azure/cosmos/implementation/RxGatewayStoreModel.java
+++ b/sdk/cosmos/azure-cosmos/src/main/java/com/azure/cosmos/implementation/RxGatewayStoreModel.java
@@ -436,7 +436,6 @@ public class RxGatewayStoreModel implements RxStoreModel, HttpTransportSerialize
                                                                       HttpRequest httpRequest) {
 
         return httpResponseMono
-            .publishOn(CosmosSchedulers.TRANSPORT_RESPONSE_BOUNDED_ELASTIC)
             .flatMap(httpResponse -> {
 
                 // header key/value pairs
@@ -482,7 +481,8 @@ public class RxGatewayStoreModel implements RxStoreModel, HttpTransportSerialize
                             // so, use safeRelease
                             safeSilentRelease(buf);
                         }
-                    });
+                    })
+                    .publishOn(CosmosSchedulers.TRANSPORT_RESPONSE_BOUNDED_ELASTIC);
 
                 return contentObservable
                     .map(content -> {

--- a/sdk/cosmos/azure-cosmos/src/main/java/com/azure/cosmos/implementation/RxGatewayStoreModel.java
+++ b/sdk/cosmos/azure-cosmos/src/main/java/com/azure/cosmos/implementation/RxGatewayStoreModel.java
@@ -228,6 +228,8 @@ public class RxGatewayStoreModel implements RxStoreModel, HttpTransportSerialize
         // If there is any error in the header response this throws exception
         validateOrThrow(request, HttpResponseStatus.valueOf(statusCode), headers, retainedContent);
 
+        Map<String, String> responseHeaders = HttpUtils.unescape(headers.toLowerCaseMap());
+
         int size;
         if ((size = retainedContent.readableBytes()) > 0) {
             if (leakDetectionDebuggingEnabled) {
@@ -238,7 +240,7 @@ public class RxGatewayStoreModel implements RxStoreModel, HttpTransportSerialize
             return new StoreResponse(
                 endpoint,
                 statusCode,
-                HttpUtils.unescape(headers.toLowerCaseMap()),
+                responseHeaders,
                 new ByteBufInputStream(retainedContent, true),
                 size);
         } else {
@@ -248,7 +250,7 @@ public class RxGatewayStoreModel implements RxStoreModel, HttpTransportSerialize
         return new StoreResponse(
             endpoint,
             statusCode,
-            HttpUtils.unescape(headers.toLowerCaseMap()),
+            responseHeaders,
             null,
             0);
     }
@@ -480,8 +482,7 @@ public class RxGatewayStoreModel implements RxStoreModel, HttpTransportSerialize
                             // so, use safeRelease
                             safeSilentRelease(buf);
                         }
-                    })
-                    .publishOn(CosmosSchedulers.TRANSPORT_RESPONSE_BOUNDED_ELASTIC);
+                    });
 
                 return contentObservable
                     .map(content -> {


### PR DESCRIPTION
Two quick-win optimizations to reduce Reactor operator overhead in gateway mode:

1. Remove redundant second publishOn (line 484) Both publishOn calls use TRANSPORT_RESPONSE_BOUNDED_ELASTIC. The second one is redundant — the flatMap body already executes on bounded-elastic from the first publishOn at line 437. Saves 1 operator + 1 thread hop.

2. Extract duplicate toLowerCaseMap() in unwrapToStoreResponse (lines 241,251) Both if/else branches called HttpUtils.unescape(headers.toLowerCaseMap()) independently, creating 2 identical HashMap allocations. Extracted to a single variable before the branch.

Note: .single() on invokeAsyncInternal() was considered for removal but kept as a defensive guard — it catches edge cases where the Mono completes empty (e.g., reactor-netty bugs, cancellation races) with a clear NoSuchElementException rather than silent empty completion.

Profiling context (async-profiler flame graphs, 30T-c3):
- Reactor operators = 62.3% of active CPU
- Each operator adds Subscriber wrapper allocations (67% of all allocs)
- Header HashMap double-alloc = ~1 extra HashMap/request (eliminated by change 2)