### PR TITLE
perf: optimize Netty HTTP/2 header processing to reduce allocations a…

### DIFF
--- a/sdk/cosmos/azure-cosmos/src/main/java/com/azure/cosmos/implementation/http/HttpHeaders.java
+++ b/sdk/cosmos/azure-cosmos/src/main/java/com/azure/cosmos/implementation/http/HttpHeaders.java
@@ -31,7 +31,7 @@ public class HttpHeaders implements Iterable<HttpHeader>, JsonSerializable {
      * Create an HttpHeaders instance with the given size.
      */
     public HttpHeaders(int size) {
-        this.headers = new HashMap<>(size);
+        this.headers = new HashMap<>((int)(size / 0.75f) + 1);
     }
 
     /**
@@ -71,6 +71,24 @@ public class HttpHeaders implements Iterable<HttpHeader>, JsonSerializable {
             headers.remove(headerKey);
         } else {
             headers.put(headerKey, new HttpHeader(name, value));
+        }
+        return this;
+    }
+
+    /**
+     * Set a header using a name that is already lowercase.
+     * Skips the toLowerCase call for callers that guarantee lowercase keys
+     * (e.g. HTTP/2 headers per RFC 7540 §8.1.2).
+     *
+     * @param lowerCaseName the header name, must already be lowercase
+     * @param value the value
+     * @return this HttpHeaders
+     */
+    HttpHeaders setLowerCase(String lowerCaseName, String value) {
+        if (value == null) {
+            headers.remove(lowerCaseName);
+        } else {
+            headers.put(lowerCaseName, new HttpHeader(lowerCaseName, value));
         }
         return this;
     }
@@ -123,9 +141,9 @@ public class HttpHeaders implements Iterable<HttpHeader>, JsonSerializable {
      * @return the headers as map
      */
     public Map<String, String> toLowerCaseMap() {
-        final Map<String, String> result = new HashMap<>(headers.size());
-        for (String headerName : headers.keySet()) {
-            result.put(headerName, headers.get(headerName).value());
+        final Map<String, String> result = new HashMap<>((int)(headers.size() / 0.75f) + 1);
+        for (Map.Entry<String, HttpHeader> entry : headers.entrySet()) {
+            result.put(entry.getKey(), entry.getValue().value());
         }
         return result;
     }

--- a/sdk/cosmos/azure-cosmos/src/main/java/com/azure/cosmos/implementation/http/ReactorNettyClient.java
+++ b/sdk/cosmos/azure-cosmos/src/main/java/com/azure/cosmos/implementation/http/ReactorNettyClient.java
@@ -13,6 +13,7 @@ import io.netty.channel.ChannelPipeline;
 import io.netty.handler.codec.http.HttpMethod;
 import io.netty.handler.logging.LogLevel;
 import io.netty.resolver.DefaultAddressResolverGroup;
+import io.netty.util.AsciiString;
 import io.netty.util.ReferenceCountUtil;
 import io.netty.util.ResourceLeakDetector;
 import org.reactivestreams.Publisher;
@@ -35,6 +36,8 @@ import reactor.util.context.Context;
 import java.lang.invoke.WrongMethodTypeException;
 import java.time.Duration;
 import java.time.Instant;
+import java.util.Iterator;
+import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.BiFunction;
@@ -391,6 +394,7 @@ public class ReactorNettyClient implements HttpClient {
 
         private final HttpClientResponse reactorNettyResponse;
         private final Connection reactorNettyConnection;
+        private HttpHeaders cachedHeaders;
 
         ReactorNettyHttpResponse(HttpClientResponse reactorNettyResponse, Connection reactorNettyConnection) {
             this.reactorNettyResponse = reactorNettyResponse;
@@ -409,9 +413,30 @@ public class ReactorNettyClient implements HttpClient {
 
         @Override
         public HttpHeaders headers() {
-            HttpHeaders headers = new HttpHeaders(reactorNettyResponse.responseHeaders().size());
-            reactorNettyResponse.responseHeaders().forEach(e -> headers.set(e.getKey(), e.getValue()));
-            return headers;
+            HttpHeaders result = cachedHeaders;
+            if (result != null) {
+                return result;
+            }
+            io.netty.handler.codec.http.HttpHeaders nettyHeaders = reactorNettyResponse.responseHeaders();
+            int size = nettyHeaders.size();
+            result = new HttpHeaders(size);
+            boolean isHttp2 = reactorNettyResponse.version().majorVersion() >= 2;
+            Iterator<Map.Entry<CharSequence, CharSequence>> it = nettyHeaders.iteratorCharSequence();
+            while (it.hasNext()) {
+                Map.Entry<CharSequence, CharSequence> entry = it.next();
+                CharSequence key = entry.getKey();
+                String value = entry.getValue().toString();
+                if (isHttp2) {
+                    // HTTP/2 header names are already lowercase per RFC 7540 §8.1.2
+                    result.setLowerCase(key.toString(), value);
+                } else if (key instanceof AsciiString) {
+                    result.setLowerCase(((AsciiString) key).toLowerCase().toString(), value);
+                } else {
+                    result.set(key.toString(), value);
+                }
+            }
+            cachedHeaders = result;
+            return result;
         }
 
         @Override


### PR DESCRIPTION
…nd CPU

- Replace forEach-based header iteration with iteratorCharSequence() in ReactorNettyHttpResponse.headers() to eliminate StringEntry wrapper allocations and lambda allocation
- Use AsciiString-aware lowercasing for HTTP/1.1 headers to avoid String.toLowerCase overhead via byte-array operations
- Skip toLowerCase entirely for HTTP/2 headers (already lowercase per RFC 7540 section 8.1.2) via new setLowerCase() fast-path method
- Fix HashMap pre-sizing in HttpHeaders constructor and toLowerCaseMap() to account for 0.75 load factor, preventing resize allocations
- Replace keySet()+get() with entrySet() iteration in toLowerCaseMap() to eliminate redundant HashMap.getNode lookups
- Cache parsed headers in ReactorNettyHttpResponse to avoid re-parsing