### PR TITLE
perf: eliminate URI construction and regex overhead on gateway hot path

### DIFF
--- a/sdk/cosmos/azure-cosmos/src/main/java/com/azure/cosmos/implementation/PathsHelper.java
+++ b/sdk/cosmos/azure-cosmos/src/main/java/com/azure/cosmos/implementation/PathsHelper.java
@@ -300,7 +300,7 @@ public class PathsHelper {
     }
 
     public static PathInfo parsePathSegments(String resourceUrl) {
-        String[] segments = StringUtils.strip(resourceUrl, "/").split("/");
+        String[] segments = StringUtils.split(StringUtils.strip(resourceUrl, "/"), '/');
         if (segments == null || segments.length < 1) {
             return null;
         }

--- a/sdk/cosmos/azure-cosmos/src/main/java/com/azure/cosmos/implementation/RxGatewayStoreModel.java
+++ b/sdk/cosmos/azure-cosmos/src/main/java/com/azure/cosmos/implementation/RxGatewayStoreModel.java
@@ -44,7 +44,6 @@ import reactor.core.publisher.Mono;
 import reactor.core.publisher.SignalType;
 
 import java.net.URI;
-import java.net.URISyntaxException;
 import java.nio.charset.StandardCharsets;
 import java.time.Instant;
 import java.util.Arrays;
@@ -194,14 +193,14 @@ public class RxGatewayStoreModel implements RxStoreModel, HttpTransportSerialize
     }
 
     @Override
-    public HttpRequest wrapInHttpRequest(RxDocumentServiceRequest request, URI requestUri) throws Exception {
+    public HttpRequest wrapInHttpRequest(RxDocumentServiceRequest request, String requestUri, int port) throws Exception {
         HttpMethod method = getHttpMethod(request);
         HttpHeaders httpHeaders = this.getHttpRequestHeaders(request.getHeaders());
 
         Flux<byte[]> contentAsByteArray = request.getContentAsByteArrayFlux();
         return new HttpRequest(method,
             requestUri,
-            requestUri.getPort(),
+            port,
             httpHeaders,
             contentAsByteArray);
     }
@@ -279,14 +278,16 @@ public class RxGatewayStoreModel implements RxStoreModel, HttpTransportSerialize
                 request.requestContext.cosmosDiagnostics = clientContext.createDiagnostics();
             }
 
-            URI uri = getUri(request);
-            request.requestContext.resourcePhysicalAddress = uri.toString();
+            URI rootUri = resolveRootUri(request);
+            int port = rootUri.getPort();
+            String uriString = buildRequestUriString(request, rootUri);
+            request.requestContext.resourcePhysicalAddress = uriString;
 
             if (this.throughputControlStore != null) {
-                return this.throughputControlStore.processRequest(request, Mono.defer(() -> this.performRequestInternal(request, uri)));
+                return this.throughputControlStore.processRequest(request, Mono.defer(() -> this.performRequestInternal(request, uriString, port)));
             }
 
-            return this.performRequestInternal(request, uri);
+            return this.performRequestInternal(request, uriString, port);
         } catch (Exception e) {
             return Mono.error(e);
         }
@@ -301,27 +302,28 @@ public class RxGatewayStoreModel implements RxStoreModel, HttpTransportSerialize
      *
      * @param request
      * @param requestUri
+     * @param port
      * @return Flux<RxDocumentServiceResponse>
      */
-    public Mono<RxDocumentServiceResponse> performRequestInternal(RxDocumentServiceRequest request, URI requestUri) {
+    public Mono<RxDocumentServiceResponse> performRequestInternal(RxDocumentServiceRequest request, String requestUri, int port) {
         if (!partitionKeyRangeResolutionNeeded(request)) {
-            return this.performRequestInternalCore(request, requestUri);
+            return this.performRequestInternalCore(request, requestUri, port);
         }
 
         return this
             .resolvePartitionKeyRangeByPkRangeId(request)
             .flatMap((pkRange) -> {
                 request.requestContext.resolvedPartitionKeyRange = pkRange;
-                return this.performRequestInternalCore(request, requestUri);
+                return this.performRequestInternalCore(request, requestUri, port);
             });
     }
 
-    private Mono<RxDocumentServiceResponse> performRequestInternalCore(RxDocumentServiceRequest request, URI requestUri) {
+    private Mono<RxDocumentServiceResponse> performRequestInternalCore(RxDocumentServiceRequest request, String requestUri, int port) {
 
         try {
             HttpRequest httpRequest = request
                 .getEffectiveHttpTransportSerializer(this)
-                .wrapInHttpRequest(request, requestUri);
+                .wrapInHttpRequest(request, requestUri, port);
 
             // Capture the request record early so it's available on both success and error paths.
             // Each retry creates a new HttpRequest with a new record, so this is per-attempt.
@@ -378,7 +380,7 @@ public class RxGatewayStoreModel implements RxStoreModel, HttpTransportSerialize
         return this.globalEndpointManager.resolveServiceEndpoint(request).getGatewayRegionalEndpoint();
     }
 
-    private URI getUri(RxDocumentServiceRequest request) throws URISyntaxException {
+    private URI resolveRootUri(RxDocumentServiceRequest request) {
         URI rootUri = request.getEndpointOverride();
         if (rootUri == null) {
             if (request.getIsMedia()) {
@@ -388,7 +390,10 @@ public class RxGatewayStoreModel implements RxStoreModel, HttpTransportSerialize
                 rootUri = getRootUri(request);
             }
         }
+        return rootUri;
+    }
 
+    private String buildRequestUriString(RxDocumentServiceRequest request, URI rootUri) {
         String path = PathsHelper.generatePath(request.getResourceType(), request, request.isFeed);
         if (request.getResourceType().equals(ResourceType.DatabaseAccount)) {
             path = StringUtils.EMPTY;
@@ -396,14 +401,17 @@ public class RxGatewayStoreModel implements RxStoreModel, HttpTransportSerialize
 
         // allow using http connections if customer opt in to use http for vnext emulator
         String scheme = HTTP_CONNECTION_WITHOUT_TLS_ALLOWED ? rootUri.getScheme() : "https";
+        String host = rootUri.getHost();
+        int port = rootUri.getPort();
+        String slashPath = ensureSlashPrefixed(path);
+        if (slashPath == null) {
+            slashPath = "";
+        }
 
-        return new URI(scheme,
-            null,
-            rootUri.getHost(),
-            rootUri.getPort(),
-            ensureSlashPrefixed(path),
-            null,  // Query string not used.
-            null);
+        if (port == -1) {
+            return scheme + "://" + host + slashPath;
+        }
+        return scheme + "://" + host + ":" + port + slashPath;
     }
 
     private String ensureSlashPrefixed(String path) {
@@ -503,7 +511,7 @@ public class RxGatewayStoreModel implements RxStoreModel, HttpTransportSerialize
                         }
                         StoreResponse rsp = request
                             .getEffectiveHttpTransportSerializer(this)
-                            .unwrapToStoreResponse(httpRequest.uri().toString(), request, httpResponseStatus, httpResponseHeaders, content);
+                            .unwrapToStoreResponse(httpRequest.uriString(), request, httpResponseStatus, httpResponseHeaders, content);
 
                         // Only clear retainedBufRef AFTER StoreResponse successfully takes ownership.
                         // If unwrapToStoreResponse throws, retainedBufRef remains set so doFinally
@@ -619,7 +627,7 @@ public class RxGatewayStoreModel implements RxStoreModel, HttpTransportSerialize
                 ImplementationBridgeHelpers
                     .CosmosExceptionHelper
                     .getCosmosExceptionAccessor()
-                    .setRequestUri(dce, Uri.create(httpRequest.uri().toString()));
+                    .setRequestUri(dce, Uri.create(httpRequest.uriString()));
 
                 if (request.requestContext.cosmosDiagnostics != null) {
                     if (httpRequest.reactorNettyRequestRecord() != null) {
@@ -671,7 +679,7 @@ public class RxGatewayStoreModel implements RxStoreModel, HttpTransportSerialize
                     ImplementationBridgeHelpers
                         .CosmosExceptionHelper
                         .getCosmosExceptionAccessor()
-                        .setRequestUri(oce, Uri.create(httpRequest.uri().toString()));
+                        .setRequestUri(oce, Uri.create(httpRequest.uriString()));
 
                     if (request.requestContext.getCrossRegionAvailabilityContext() != null) {
 

--- a/sdk/cosmos/azure-cosmos/src/main/java/com/azure/cosmos/implementation/ThinClientStoreModel.java
+++ b/sdk/cosmos/azure-cosmos/src/main/java/com/azure/cosmos/implementation/ThinClientStoreModel.java
@@ -188,7 +188,7 @@ public class ThinClientStoreModel extends RxGatewayStoreModel {
     }
 
     @Override
-    public Mono<RxDocumentServiceResponse> performRequestInternal(RxDocumentServiceRequest request, URI requestUri) {
+    public Mono<RxDocumentServiceResponse> performRequestInternal(RxDocumentServiceRequest request, String requestUri, int port) {
         // Ensure partitionKeyDefinition is resolved from the collection cache before
         // reaching wrapInHttpRequest, which needs it for client-side EPK computation.
         // This handles cases where clone() or other code paths didn't propagate partitionKeyDefinition.
@@ -208,16 +208,16 @@ public class ThinClientStoreModel extends RxGatewayStoreModel {
                                     + request.getResourceAddress()
                                     + ". Cannot resolve partitionKeyDefinition for client-side EPK computation.");
                         }
-                        return super.performRequestInternal(request, requestUri);
+                        return super.performRequestInternal(request, requestUri, port);
                     });
             }
         }
 
-        return super.performRequestInternal(request, requestUri);
+        return super.performRequestInternal(request, requestUri, port);
     }
 
     @Override
-    public HttpRequest wrapInHttpRequest(RxDocumentServiceRequest request, URI requestUri) throws Exception {
+    public HttpRequest wrapInHttpRequest(RxDocumentServiceRequest request, String requestUri, int port) throws Exception {
         if (this.globalDatabaseAccountName == null) {
             this.globalDatabaseAccountName = this.globalEndpointManager.getLatestDatabaseAccount().getId();
         }
@@ -265,7 +265,7 @@ public class ThinClientStoreModel extends RxGatewayStoreModel {
             return new HttpRequest(
                 HttpMethod.POST,
                 requestUri,
-                requestUri.getPort(),
+                port,
                 headers,
                 Flux.just(contentAsByteArray))
                 .withThinClientRequest(true);

--- a/sdk/cosmos/azure-cosmos/src/main/java/com/azure/cosmos/implementation/directconnectivity/HttpUtils.java
+++ b/sdk/cosmos/azure-cosmos/src/main/java/com/azure/cosmos/implementation/directconnectivity/HttpUtils.java
@@ -22,18 +22,15 @@ import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
-import java.util.regex.Pattern;
 
 public class HttpUtils {
 
     private static Logger log = LoggerFactory.getLogger(HttpUtils.class);
 
-    private static final Pattern PLUS_SYMBOL_ESCAPE_PATTERN = Pattern.compile(UrlEncodingInfo.PLUS_SYMBOL_ESCAPED);
-
     public static String urlEncode(String url) {
         try {
-            return PLUS_SYMBOL_ESCAPE_PATTERN.matcher(URLEncoder.encode(url, UrlEncodingInfo.UTF_8))
-                .replaceAll(UrlEncodingInfo.SINGLE_SPACE_URI_ENCODING);
+            return URLEncoder.encode(url, UrlEncodingInfo.UTF_8)
+                .replace("+", UrlEncodingInfo.SINGLE_SPACE_URI_ENCODING);
         } catch (UnsupportedEncodingException e) {
             log.error("failed to encode {}", url, e);
             throw new IllegalArgumentException("failed to encode url " + url, e);
@@ -42,7 +39,7 @@ public class HttpUtils {
 
     public static String urlDecode(String url) {
         try {
-            return URLDecoder.decode(PLUS_SYMBOL_ESCAPE_PATTERN.matcher(url).replaceAll(UrlEncodingInfo.PLUS_SYMBOL_URI_ENCODING),
+            return URLDecoder.decode(url.replace("+", UrlEncodingInfo.PLUS_SYMBOL_URI_ENCODING),
                 UrlEncodingInfo.UTF_8);
         } catch (UnsupportedEncodingException e) {
             log.error("failed to decode {}", url, e);

--- a/sdk/cosmos/azure-cosmos/src/main/java/com/azure/cosmos/implementation/http/HttpRequest.java
+++ b/sdk/cosmos/azure-cosmos/src/main/java/com/azure/cosmos/implementation/http/HttpRequest.java
@@ -16,6 +16,7 @@ import java.time.Instant;
 public class HttpRequest {
     private HttpMethod httpMethod;
     private URI uri;
+    private String uriString;
     private int port;
     private HttpHeaders headers;
     private Flux<byte[]> body;
@@ -44,7 +45,7 @@ public class HttpRequest {
      */
     public HttpRequest(HttpMethod httpMethod, String uri, int port) throws URISyntaxException {
         this.httpMethod = httpMethod;
-        this.uri = new URI(uri);
+        this.uriString = uri;
         this.port = port;
         this.headers = new HttpHeaders();
         this.reactorNettyRequestRecord = createReactorNettyRequestRecord();
@@ -61,6 +62,25 @@ public class HttpRequest {
     public HttpRequest(HttpMethod httpMethod, URI uri, int port, HttpHeaders headers, Flux<byte[]> body) {
         this.httpMethod = httpMethod;
         this.uri = uri;
+        this.port = port;
+        this.headers = headers;
+        this.body = body;
+        this.reactorNettyRequestRecord = createReactorNettyRequestRecord();
+    }
+
+    /**
+     * Create a new HttpRequest instance with a pre-built URI string.
+     * The URI object is lazily constructed only when {@link #uri()} is called.
+     *
+     * @param httpMethod the HTTP request method
+     * @param uriString  the target address as a pre-built string
+     * @param port       the target port
+     * @param headers    the HTTP headers to use with this request
+     * @param body       the request content
+     */
+    public HttpRequest(HttpMethod httpMethod, String uriString, int port, HttpHeaders headers, Flux<byte[]> body) {
+        this.httpMethod = httpMethod;
+        this.uriString = uriString;
         this.port = port;
         this.headers = headers;
         this.body = body;
@@ -113,7 +133,22 @@ public class HttpRequest {
      * @return the target address
      */
     public URI uri() {
+        if (uri == null && uriString != null) {
+            uri = URI.create(uriString);
+        }
         return uri;
+    }
+
+    /**
+     * Get the target address as a string without constructing a URI object.
+     *
+     * @return the target address string
+     */
+    public String uriString() {
+        if (uriString == null && uri != null) {
+            uriString = uri.toString();
+        }
+        return uriString;
     }
 
     /**
@@ -124,6 +159,7 @@ public class HttpRequest {
      */
     public HttpRequest withUri(URI uri) {
         this.uri = uri;
+        this.uriString = null;
         return this;
     }
 

--- a/sdk/cosmos/azure-cosmos/src/main/java/com/azure/cosmos/implementation/http/HttpTransportSerializer.java
+++ b/sdk/cosmos/azure-cosmos/src/main/java/com/azure/cosmos/implementation/http/HttpTransportSerializer.java
@@ -4,10 +4,8 @@ import com.azure.cosmos.implementation.RxDocumentServiceRequest;
 import com.azure.cosmos.implementation.directconnectivity.StoreResponse;
 import io.netty.buffer.ByteBuf;
 
-import java.net.URI;
-
 public interface HttpTransportSerializer {
-    HttpRequest wrapInHttpRequest(RxDocumentServiceRequest request, URI requestUri) throws Exception;
+    HttpRequest wrapInHttpRequest(RxDocumentServiceRequest request, String requestUri, int port) throws Exception;
 
     StoreResponse unwrapToStoreResponse(
         String endpoint,

--- a/sdk/cosmos/azure-cosmos/src/main/java/com/azure/cosmos/implementation/http/ReactorNettyClient.java
+++ b/sdk/cosmos/azure-cosmos/src/main/java/com/azure/cosmos/implementation/http/ReactorNettyClient.java
@@ -176,7 +176,7 @@ public class ReactorNettyClient implements HttpClient {
     @Override
     public Mono<HttpResponse> send(final HttpRequest request, Duration responseTimeout) {
         Objects.requireNonNull(request.httpMethod());
-        Objects.requireNonNull(request.uri());
+        Objects.requireNonNull(request.uriString());
         Objects.requireNonNull(this.httpClientConfig);
         if(request.reactorNettyRequestRecord() == null) {
             ReactorNettyRequestRecord reactorNettyRequestRecord = new ReactorNettyRequestRecord();
@@ -202,7 +202,7 @@ public class ReactorNettyClient implements HttpClient {
             .option(ChannelOption.CONNECT_TIMEOUT_MILLIS, connectTimeoutMs)
             .responseTimeout(responseTimeout)
             .request(HttpMethod.valueOf(request.httpMethod().toString()))
-            .uri(request.uri().toASCIIString())
+            .uri(request.uriString())
             .send(bodySendDelegate(request))
             .responseConnection((reactorNettyResponse, reactorNettyConnection) -> {
                 HttpResponse httpResponse = new ReactorNettyHttpResponse(reactorNettyResponse,


### PR DESCRIPTION
- Replace 7-arg URI constructor in RxGatewayStoreModel.getUri() with direct string building, avoiding URI\.parseHierarchical/scan regex overhead
- Add string-first URI representation to HttpRequest with lazy URI construction (URI object only created when uri() is called, not on the hot path)
- Update ReactorNettyClient to use request.uriString() instead of request.uri().toASCIIString(), bypassing URI object creation entirely
- Replace regex Pattern.matcher().replaceAll() in HttpUtils.urlEncode/urlDecode with String.replace() for literal character replacement
- Replace String.split(\"/\") in PathsHelper.parsePathSegments() with StringUtils.split() for char-based splitting without regex compilation

JFR evidence: URI\.parseHierarchical=1.23%, URI\.scan=0.86%, Pattern\.match=0.98% of CPU samples.