### PR TITLE
Move benchmark dispatch from per-tenant to orchestrator level

### DIFF
--- a/sdk/cosmos/azure-cosmos-benchmark/src/main/java/com/azure/cosmos/benchmark/AsyncBenchmark.java
+++ b/sdk/cosmos/azure-cosmos-benchmark/src/main/java/com/azure/cosmos/benchmark/AsyncBenchmark.java
@@ -336,6 +336,11 @@ abstract class AsyncBenchmark<T> implements Benchmark {
     protected abstract Mono<T> performWorkload(long i);
 
     @Override
+    public boolean isDispatchable() {
+        return true;
+    }
+
+    @Override
     public Mono<?> performSingleOperation(long operationIndex) {
         Mono<T> workload = performWorkload(operationIndex);
         Mono<T> delayed = sparsityMono(operationIndex);

--- a/sdk/cosmos/azure-cosmos-benchmark/src/main/java/com/azure/cosmos/benchmark/AsyncBenchmark.java
+++ b/sdk/cosmos/azure-cosmos-benchmark/src/main/java/com/azure/cosmos/benchmark/AsyncBenchmark.java
@@ -343,9 +343,10 @@ abstract class AsyncBenchmark<T> implements Benchmark {
     @Override
     public Mono<?> performSingleOperation(long operationIndex) {
         // NOTE: This dispatch-wrapping pattern (sparsity + subscribe + onSuccess + onError)
-        // is duplicated in AsyncEncryptionBenchmark and AsyncCtlWorkload (different packages).
-        // If modifying this logic, update those performSingleOperation() implementations too.
-        // A shared helper cannot be package-private because those classes are in sub-packages.
+        // is duplicated in AsyncEncryptionBenchmark, AsyncCtlWorkload, and SyncBenchmark
+        // (different packages). A shared static helper or abstract base would reduce duplication,
+        // but is impractical because those classes are in sub-packages that cannot access
+        // package-private members. If modifying this logic, update all 4 implementations.
         Mono<T> workload = performWorkload(operationIndex);
         Mono<T> delayed = sparsityMono(operationIndex);
         if (delayed != null) {
@@ -355,9 +356,13 @@ abstract class AsyncBenchmark<T> implements Benchmark {
             .subscribeOn(benchmarkScheduler)
             .doOnSuccess(v -> AsyncBenchmark.this.onSuccess())
             .doOnError(e -> {
-                logger.error("Encountered failure {} on thread {}",
-                    e.getMessage(), Thread.currentThread().getName(), e);
-                AsyncBenchmark.this.onError(e);
+                try {
+                    logger.error("Encountered failure {} on thread {}",
+                        e.getMessage(), Thread.currentThread().getName(), e);
+                    AsyncBenchmark.this.onError(e);
+                } catch (Exception handlerEx) {
+                    logger.error("onError handler threw for original error: {}", e.getMessage(), handlerEx);
+                }
             });
     }
 

--- a/sdk/cosmos/azure-cosmos-benchmark/src/main/java/com/azure/cosmos/benchmark/AsyncBenchmark.java
+++ b/sdk/cosmos/azure-cosmos-benchmark/src/main/java/com/azure/cosmos/benchmark/AsyncBenchmark.java
@@ -342,28 +342,14 @@ abstract class AsyncBenchmark<T> implements Benchmark {
 
     @Override
     public Mono<?> performSingleOperation(long operationIndex) {
-        // NOTE: This dispatch-wrapping pattern (sparsity + subscribe + onSuccess + onError)
-        // is duplicated in AsyncEncryptionBenchmark, AsyncCtlWorkload, and SyncBenchmark
-        // (different packages). A shared static helper or abstract base would reduce duplication,
-        // but is impractical because those classes are in sub-packages that cannot access
-        // package-private members. If modifying this logic, update all 4 implementations.
         Mono<T> workload = performWorkload(operationIndex);
         Mono<T> delayed = sparsityMono(operationIndex);
         if (delayed != null) {
             workload = delayed.then(workload);
         }
-        return workload
-            .subscribeOn(benchmarkScheduler)
-            .doOnSuccess(v -> AsyncBenchmark.this.onSuccess())
-            .doOnError(e -> {
-                try {
-                    logger.error("Encountered failure {} on thread {}",
-                        e.getMessage(), Thread.currentThread().getName(), e);
-                    AsyncBenchmark.this.onError(e);
-                } catch (Exception handlerEx) {
-                    logger.error("onError handler threw for original error: {}", e.getMessage(), handlerEx);
-                }
-            });
+        return Benchmark.wrapDispatchCallbacks(
+            workload.subscribeOn(benchmarkScheduler),
+            this::onSuccess, this::onError, logger);
     }
 
     @SuppressWarnings("unchecked")

--- a/sdk/cosmos/azure-cosmos-benchmark/src/main/java/com/azure/cosmos/benchmark/AsyncBenchmark.java
+++ b/sdk/cosmos/azure-cosmos-benchmark/src/main/java/com/azure/cosmos/benchmark/AsyncBenchmark.java
@@ -342,6 +342,9 @@ abstract class AsyncBenchmark<T> implements Benchmark {
 
     @Override
     public Mono<?> performSingleOperation(long operationIndex) {
+        // NOTE: This dispatch-wrapping pattern (sparsity + subscribe + onSuccess + onError + resume)
+        // is duplicated in AsyncEncryptionBenchmark, which doesn't extend this class.
+        // If modifying this logic, update AsyncEncryptionBenchmark.performSingleOperation() too.
         Mono<T> workload = performWorkload(operationIndex);
         Mono<T> delayed = sparsityMono(operationIndex);
         if (delayed != null) {

--- a/sdk/cosmos/azure-cosmos-benchmark/src/main/java/com/azure/cosmos/benchmark/AsyncBenchmark.java
+++ b/sdk/cosmos/azure-cosmos-benchmark/src/main/java/com/azure/cosmos/benchmark/AsyncBenchmark.java
@@ -369,6 +369,10 @@ abstract class AsyncBenchmark<T> implements Benchmark {
     @SuppressWarnings("unchecked")
     public void run() throws Exception {
 
+        // Note: legacy run() uses System.currentTimeMillis() for deadline (wall-clock).
+        // The orchestrator dispatch path uses System.nanoTime() (monotonic) instead.
+        // This is acceptable here because standalone legacy runs are short-lived and
+        // NTP clock skew is negligible for typical benchmark durations.
         long startTime = System.currentTimeMillis();
         int concurrency = workloadConfig.getConcurrency();
 

--- a/sdk/cosmos/azure-cosmos-benchmark/src/main/java/com/azure/cosmos/benchmark/AsyncBenchmark.java
+++ b/sdk/cosmos/azure-cosmos-benchmark/src/main/java/com/azure/cosmos/benchmark/AsyncBenchmark.java
@@ -342,9 +342,10 @@ abstract class AsyncBenchmark<T> implements Benchmark {
 
     @Override
     public Mono<?> performSingleOperation(long operationIndex) {
-        // NOTE: This dispatch-wrapping pattern (sparsity + subscribe + onSuccess + onError + resume)
-        // is duplicated in AsyncEncryptionBenchmark, which doesn't extend this class.
-        // If modifying this logic, update AsyncEncryptionBenchmark.performSingleOperation() too.
+        // NOTE: This dispatch-wrapping pattern (sparsity + subscribe + onSuccess + onError)
+        // is duplicated in AsyncEncryptionBenchmark and AsyncCtlWorkload (different packages).
+        // If modifying this logic, update those performSingleOperation() implementations too.
+        // A shared helper cannot be package-private because those classes are in sub-packages.
         Mono<T> workload = performWorkload(operationIndex);
         Mono<T> delayed = sparsityMono(operationIndex);
         if (delayed != null) {
@@ -357,8 +358,7 @@ abstract class AsyncBenchmark<T> implements Benchmark {
                 logger.error("Encountered failure {} on thread {}",
                     e.getMessage(), Thread.currentThread().getName(), e);
                 AsyncBenchmark.this.onError(e);
-            })
-            .onErrorResume(e -> Mono.empty());
+            });
     }
 
     @SuppressWarnings("unchecked")

--- a/sdk/cosmos/azure-cosmos-benchmark/src/main/java/com/azure/cosmos/benchmark/AsyncBenchmark.java
+++ b/sdk/cosmos/azure-cosmos-benchmark/src/main/java/com/azure/cosmos/benchmark/AsyncBenchmark.java
@@ -335,6 +335,24 @@ abstract class AsyncBenchmark<T> implements Benchmark {
 
     protected abstract Mono<T> performWorkload(long i);
 
+    @Override
+    public Mono<?> performSingleOperation(long operationIndex) {
+        Mono<T> workload = performWorkload(operationIndex);
+        Mono<T> delayed = sparsityMono(operationIndex);
+        if (delayed != null) {
+            workload = delayed.then(workload);
+        }
+        return workload
+            .subscribeOn(benchmarkScheduler)
+            .doOnSuccess(v -> AsyncBenchmark.this.onSuccess())
+            .doOnError(e -> {
+                logger.error("Encountered failure {} on thread {}",
+                    e.getMessage(), Thread.currentThread().getName(), e);
+                AsyncBenchmark.this.onError(e);
+            })
+            .onErrorResume(e -> Mono.empty());
+    }
+
     @SuppressWarnings("unchecked")
     public void run() throws Exception {
 

--- a/sdk/cosmos/azure-cosmos-benchmark/src/main/java/com/azure/cosmos/benchmark/Benchmark.java
+++ b/sdk/cosmos/azure-cosmos-benchmark/src/main/java/com/azure/cosmos/benchmark/Benchmark.java
@@ -3,7 +3,10 @@
 
 package com.azure.cosmos.benchmark;
 
+import org.slf4j.Logger;
 import reactor.core.publisher.Mono;
+
+import java.util.function.Consumer;
 
 /**
  * Common contract for all benchmark workloads.
@@ -45,5 +48,32 @@ public interface Benchmark {
      */
     default boolean isDispatchable() {
         return false;
+    }
+
+    /**
+     * Wraps a dispatch Mono with standard success/error observability callbacks.
+     * Centralizes the try-catch error-logging pattern used by AsyncBenchmark,
+     * AsyncEncryptionBenchmark, and SyncBenchmark to avoid copy-paste drift.
+     *
+     * @param source     the operation Mono (already subscribeOn'd by the caller)
+     * @param onSuccess  callback invoked on success (e.g. metrics increment)
+     * @param onError    callback invoked on error (e.g. metrics increment)
+     * @param logger     the caller's logger for error messages
+     * @param <T>        the Mono element type
+     * @return the wrapped Mono
+     */
+    static <T> Mono<T> wrapDispatchCallbacks(Mono<T> source, Runnable onSuccess,
+                                              Consumer<Throwable> onError, Logger logger) {
+        return source
+            .doOnSuccess(v -> onSuccess.run())
+            .doOnError(e -> {
+                try {
+                    logger.error("Encountered failure {} on thread {}",
+                        e.getMessage(), Thread.currentThread().getName(), e);
+                    onError.accept(e);
+                } catch (Exception handlerEx) {
+                    logger.error("onError handler threw for original error: {}", e.getMessage(), handlerEx);
+                }
+            });
     }
 }

--- a/sdk/cosmos/azure-cosmos-benchmark/src/main/java/com/azure/cosmos/benchmark/Benchmark.java
+++ b/sdk/cosmos/azure-cosmos-benchmark/src/main/java/com/azure/cosmos/benchmark/Benchmark.java
@@ -19,6 +19,11 @@ import reactor.core.publisher.Mono;
  * {@code false}; the orchestrator will call {@link #run()} directly for those.</p>
  */
 public interface Benchmark {
+    /**
+     * Run the full benchmark workload. For dispatchable benchmarks, this is the legacy
+     * execution path retained for standalone / non-orchestrator usage. The orchestrator
+     * uses {@link #performSingleOperation(long)} instead.
+     */
     void run() throws Exception;
     void shutdown();
 
@@ -39,6 +44,6 @@ public interface Benchmark {
      * Non-dispatchable benchmarks are run via {@link #run()} in their own thread.
      */
     default boolean isDispatchable() {
-        return true;
+        return false;
     }
 }

--- a/sdk/cosmos/azure-cosmos-benchmark/src/main/java/com/azure/cosmos/benchmark/Benchmark.java
+++ b/sdk/cosmos/azure-cosmos-benchmark/src/main/java/com/azure/cosmos/benchmark/Benchmark.java
@@ -3,12 +3,42 @@
 
 package com.azure.cosmos.benchmark;
 
+import reactor.core.publisher.Mono;
+
 /**
  * Common contract for all benchmark workloads.
  * Implementations are created by {@link BenchmarkOrchestrator} and participate
  * in its lifecycle loop (create → run → shutdown → settle × N cycles).
+ *
+ * <p>Workloads that support per-operation dispatch by the orchestrator should
+ * implement {@link #performSingleOperation(long)}. The orchestrator calls this
+ * method for each operation slot, passing a <em>tenant-local</em> operation index.</p>
+ *
+ * <p>Workloads with complex lifecycles (e.g. {@code LICtlWorkload}) that cannot
+ * be dispatched per-operation should override {@link #isDispatchable()} to return
+ * {@code false}; the orchestrator will call {@link #run()} directly for those.</p>
  */
 public interface Benchmark {
     void run() throws Exception;
     void shutdown();
+
+    /**
+     * Execute a single operation for this benchmark. The orchestrator calls this
+     * when randomly selecting this tenant for an operation slot.
+     *
+     * @param operationIndex tenant-local operation index (0-based, monotonically increasing per tenant)
+     * @return a Mono that completes when the operation finishes
+     */
+    default Mono<?> performSingleOperation(long operationIndex) {
+        return Mono.error(new UnsupportedOperationException(
+            getClass().getSimpleName() + " does not support per-operation dispatch"));
+    }
+
+    /**
+     * Whether this benchmark supports per-operation dispatch from the orchestrator.
+     * Non-dispatchable benchmarks are run via {@link #run()} in their own thread.
+     */
+    default boolean isDispatchable() {
+        return true;
+    }
 }

--- a/sdk/cosmos/azure-cosmos-benchmark/src/main/java/com/azure/cosmos/benchmark/BenchmarkConfig.java
+++ b/sdk/cosmos/azure-cosmos-benchmark/src/main/java/com/azure/cosmos/benchmark/BenchmarkConfig.java
@@ -56,6 +56,7 @@ public class BenchmarkConfig {
     private long numberOfOperations = 100000;
     private boolean numberOfOperationsExplicitlySet = false;
     private String maxRunningTimeDuration;
+    private java.time.Duration maxRunningTimeDurationParsed;
 
     // -- Tenants (each carries its full effective config) --
     private List<TenantWorkloadConfig> tenantWorkloads = Collections.emptyList();
@@ -135,8 +136,7 @@ public class BenchmarkConfig {
     public String getMaxRunningTimeDuration() { return maxRunningTimeDuration; }
 
     public java.time.Duration getMaxRunningTimeDurationParsed() {
-        if (maxRunningTimeDuration == null) return null;
-        return java.time.Duration.parse(maxRunningTimeDuration);
+        return maxRunningTimeDurationParsed;
     }
 
     public List<TenantWorkloadConfig> getTenantWorkloads() { return tenantWorkloads; }
@@ -198,6 +198,7 @@ public class BenchmarkConfig {
                     throw new IllegalArgumentException(
                         "maxRunningTimeDuration must be positive, got: '" + maxRunningTimeDuration + "'");
                 }
+                maxRunningTimeDurationParsed = d;
             } catch (java.time.format.DateTimeParseException e) {
                 throw new IllegalArgumentException(
                     "maxRunningTimeDuration is not a valid ISO-8601 duration: '"

--- a/sdk/cosmos/azure-cosmos-benchmark/src/main/java/com/azure/cosmos/benchmark/BenchmarkConfig.java
+++ b/sdk/cosmos/azure-cosmos-benchmark/src/main/java/com/azure/cosmos/benchmark/BenchmarkConfig.java
@@ -170,13 +170,22 @@ public class BenchmarkConfig {
      */
     private void loadDispatchConfig(JsonNode root) {
         if (root.has("concurrency")) {
-            concurrency = Integer.parseInt(root.get("concurrency").asText());
+            concurrency = root.get("concurrency").asInt(concurrency);
         }
         if (root.has("numberOfOperations")) {
-            numberOfOperations = Integer.parseInt(root.get("numberOfOperations").asText());
+            numberOfOperations = root.get("numberOfOperations").asInt(numberOfOperations);
         }
         if (root.has("maxRunningTimeDuration")) {
             maxRunningTimeDuration = root.get("maxRunningTimeDuration").asText();
+        }
+
+        if (concurrency <= 0) {
+            throw new IllegalArgumentException(
+                "concurrency must be a positive integer, got: " + concurrency);
+        }
+        if (numberOfOperations <= 0) {
+            throw new IllegalArgumentException(
+                "numberOfOperations must be a positive integer, got: " + numberOfOperations);
         }
     }
 

--- a/sdk/cosmos/azure-cosmos-benchmark/src/main/java/com/azure/cosmos/benchmark/BenchmarkConfig.java
+++ b/sdk/cosmos/azure-cosmos-benchmark/src/main/java/com/azure/cosmos/benchmark/BenchmarkConfig.java
@@ -49,6 +49,11 @@ public class BenchmarkConfig {
     private boolean isPerPartitionAutomaticFailoverRequired = true;
     private int minConnectionPoolSizePerEndpoint = 0;
 
+    // -- Orchestrator-level dispatch (controls total workload, not per-tenant) --
+    private int concurrency = 1000;
+    private int numberOfOperations = 100000;
+    private String maxRunningTimeDuration;
+
     // -- Tenants (each carries its full effective config) --
     private List<TenantWorkloadConfig> tenantWorkloads = Collections.emptyList();
 
@@ -121,16 +126,27 @@ public class BenchmarkConfig {
     public boolean isPerPartitionAutomaticFailoverRequired() { return isPerPartitionAutomaticFailoverRequired; }
     public int getMinConnectionPoolSizePerEndpoint() { return minConnectionPoolSizePerEndpoint; }
 
+    public int getConcurrency() { return concurrency; }
+    public int getNumberOfOperations() { return numberOfOperations; }
+    public String getMaxRunningTimeDuration() { return maxRunningTimeDuration; }
+
+    public java.time.Duration getMaxRunningTimeDurationParsed() {
+        if (maxRunningTimeDuration == null) return null;
+        return java.time.Duration.parse(maxRunningTimeDuration);
+    }
+
     public List<TenantWorkloadConfig> getTenantWorkloads() { return tenantWorkloads; }
 
     @Override
     public String toString() {
         return String.format(
             "BenchmarkConfig{cycles=%d, settleTimeMs=%d, suppressCleanup=%s, " +
-            "gcBetweenCycles=%s, tenants=%d, reportingDestination=%s, " +
+            "gcBetweenCycles=%s, tenants=%d, concurrency=%d, numberOfOperations=%d, " +
+            "maxRunningTimeDuration=%s, reportingDestination=%s, " +
             "circuitBreaker=%s, ppaf=%s, minConnPoolSize=%d}",
             cycles, settleTimeMs, suppressCleanup, gcBetweenCycles,
-            tenantWorkloads.size(), getReportingDestination(),
+            tenantWorkloads.size(), concurrency, numberOfOperations,
+            maxRunningTimeDuration, getReportingDestination(),
             isPartitionLevelCircuitBreakerEnabled, isPerPartitionAutomaticFailoverRequired,
             minConnectionPoolSizePerEndpoint);
     }
@@ -143,8 +159,25 @@ public class BenchmarkConfig {
         ObjectMapper mapper = new ObjectMapper();
         JsonNode root = mapper.readTree(workloadConfigFile);
 
+        loadDispatchConfig(root);
         loadJvmSystemProperties(root);
         loadMetricsConfig(root);
+    }
+
+    /**
+     * Orchestrator-level dispatch settings from the JSON root.
+     * These control how many total operations to run and with what concurrency.
+     */
+    private void loadDispatchConfig(JsonNode root) {
+        if (root.has("concurrency")) {
+            concurrency = Integer.parseInt(root.get("concurrency").asText());
+        }
+        if (root.has("numberOfOperations")) {
+            numberOfOperations = Integer.parseInt(root.get("numberOfOperations").asText());
+        }
+        if (root.has("maxRunningTimeDuration")) {
+            maxRunningTimeDuration = root.get("maxRunningTimeDuration").asText();
+        }
     }
 
     /**

--- a/sdk/cosmos/azure-cosmos-benchmark/src/main/java/com/azure/cosmos/benchmark/BenchmarkConfig.java
+++ b/sdk/cosmos/azure-cosmos-benchmark/src/main/java/com/azure/cosmos/benchmark/BenchmarkConfig.java
@@ -50,8 +50,10 @@ public class BenchmarkConfig {
     private int minConnectionPoolSizePerEndpoint = 0;
 
     // -- Orchestrator-level dispatch (controls total workload, not per-tenant) --
+    // In dispatch mode, per-tenant concurrency and numberOfOperations in TenantWorkloadConfig
+    // are ignored — the orchestrator-level values below control the total workload.
     private int concurrency = 1000;
-    private int numberOfOperations = 100000;
+    private long numberOfOperations = 100000;
     private boolean numberOfOperationsExplicitlySet = false;
     private String maxRunningTimeDuration;
 
@@ -128,7 +130,7 @@ public class BenchmarkConfig {
     public int getMinConnectionPoolSizePerEndpoint() { return minConnectionPoolSizePerEndpoint; }
 
     public int getConcurrency() { return concurrency; }
-    public int getNumberOfOperations() { return numberOfOperations; }
+    public long getNumberOfOperations() { return numberOfOperations; }
     public boolean isNumberOfOperationsExplicitlySet() { return numberOfOperationsExplicitlySet; }
     public String getMaxRunningTimeDuration() { return maxRunningTimeDuration; }
 
@@ -175,14 +177,18 @@ public class BenchmarkConfig {
             concurrency = root.get("concurrency").asInt(concurrency);
         }
         if (root.has("numberOfOperations")) {
-            numberOfOperations = root.get("numberOfOperations").asInt(numberOfOperations);
+            numberOfOperations = root.get("numberOfOperations").asLong(numberOfOperations);
             numberOfOperationsExplicitlySet = true;
         }
         if (root.has("maxRunningTimeDuration")) {
             maxRunningTimeDuration = root.get("maxRunningTimeDuration").asText();
             // Validate eagerly so malformed values surface at config-load time
             try {
-                java.time.Duration.parse(maxRunningTimeDuration);
+                java.time.Duration d = java.time.Duration.parse(maxRunningTimeDuration);
+                if (d.isZero() || d.isNegative()) {
+                    throw new IllegalArgumentException(
+                        "maxRunningTimeDuration must be positive, got: '" + maxRunningTimeDuration + "'");
+                }
             } catch (java.time.format.DateTimeParseException e) {
                 throw new IllegalArgumentException(
                     "maxRunningTimeDuration is not a valid ISO-8601 duration: '"

--- a/sdk/cosmos/azure-cosmos-benchmark/src/main/java/com/azure/cosmos/benchmark/BenchmarkConfig.java
+++ b/sdk/cosmos/azure-cosmos-benchmark/src/main/java/com/azure/cosmos/benchmark/BenchmarkConfig.java
@@ -169,6 +169,15 @@ public class BenchmarkConfig {
     }
 
     /**
+     * Loads dispatch config from a JSON file. Package-private for testing.
+     */
+    void loadDispatchConfigFromFile(File configFile) throws IOException {
+        ObjectMapper mapper = new ObjectMapper();
+        JsonNode root = mapper.readTree(configFile);
+        loadDispatchConfig(root);
+    }
+
+    /**
      * Orchestrator-level dispatch settings from the JSON root.
      * These control how many total operations to run and with what concurrency.
      */

--- a/sdk/cosmos/azure-cosmos-benchmark/src/main/java/com/azure/cosmos/benchmark/BenchmarkConfig.java
+++ b/sdk/cosmos/azure-cosmos-benchmark/src/main/java/com/azure/cosmos/benchmark/BenchmarkConfig.java
@@ -52,6 +52,7 @@ public class BenchmarkConfig {
     // -- Orchestrator-level dispatch (controls total workload, not per-tenant) --
     private int concurrency = 1000;
     private int numberOfOperations = 100000;
+    private boolean numberOfOperationsExplicitlySet = false;
     private String maxRunningTimeDuration;
 
     // -- Tenants (each carries its full effective config) --
@@ -128,6 +129,7 @@ public class BenchmarkConfig {
 
     public int getConcurrency() { return concurrency; }
     public int getNumberOfOperations() { return numberOfOperations; }
+    public boolean isNumberOfOperationsExplicitlySet() { return numberOfOperationsExplicitlySet; }
     public String getMaxRunningTimeDuration() { return maxRunningTimeDuration; }
 
     public java.time.Duration getMaxRunningTimeDurationParsed() {
@@ -174,9 +176,18 @@ public class BenchmarkConfig {
         }
         if (root.has("numberOfOperations")) {
             numberOfOperations = root.get("numberOfOperations").asInt(numberOfOperations);
+            numberOfOperationsExplicitlySet = true;
         }
         if (root.has("maxRunningTimeDuration")) {
             maxRunningTimeDuration = root.get("maxRunningTimeDuration").asText();
+            // Validate eagerly so malformed values surface at config-load time
+            try {
+                java.time.Duration.parse(maxRunningTimeDuration);
+            } catch (java.time.format.DateTimeParseException e) {
+                throw new IllegalArgumentException(
+                    "maxRunningTimeDuration is not a valid ISO-8601 duration: '"
+                        + maxRunningTimeDuration + "'", e);
+            }
         }
 
         if (concurrency <= 0) {

--- a/sdk/cosmos/azure-cosmos-benchmark/src/main/java/com/azure/cosmos/benchmark/BenchmarkOrchestrator.java
+++ b/sdk/cosmos/azure-cosmos-benchmark/src/main/java/com/azure/cosmos/benchmark/BenchmarkOrchestrator.java
@@ -307,6 +307,9 @@ public class BenchmarkOrchestrator {
      * {@link TenantWorkloadConfig} are not used during orchestrator dispatch — the
      * orchestrator-level settings in {@link BenchmarkConfig} control the total workload.
      * Non-dispatchable benchmarks (e.g. LICtlWorkload) run via their own run() in a separate thread.
+     *
+     * <p>TODO: Consider weighted tenant selection based on per-tenant config
+     * (e.g., a weight field in TenantWorkloadConfig) for reproducing realistic traffic ratios.</p>
      */
     private void runWorkload(List<Benchmark> benchmarks, int cycle, BenchmarkConfig config) throws Exception {
         // Separate dispatchable from non-dispatchable benchmarks
@@ -325,7 +328,11 @@ public class BenchmarkOrchestrator {
         List<Future<?>> legacyFutures = new ArrayList<>();
         if (!nonDispatchable.isEmpty()) {
             logger.info("Running {} non-dispatchable benchmark(s) in legacy mode", nonDispatchable.size());
-            legacyExecutor = Executors.newFixedThreadPool(nonDispatchable.size());
+            legacyExecutor = Executors.newFixedThreadPool(nonDispatchable.size(), r -> {
+                Thread t = new Thread(r, "legacy-dispatch-" + r.hashCode());
+                t.setDaemon(true);
+                return t;
+            });
             final int currentCycle = cycle;
             for (Benchmark benchmark : nonDispatchable) {
                 legacyFutures.add(legacyExecutor.submit(() -> {
@@ -346,9 +353,9 @@ public class BenchmarkOrchestrator {
                 Duration maxDuration = config.getMaxRunningTimeDurationParsed();
                 long workloadStartTime = System.currentTimeMillis();
 
-                // Log precedence when both limits are set
-                if (maxDuration != null && numberOfOps > 0) {
-                    logger.warn("Both maxRunningTimeDuration ({}) and numberOfOperations ({}) are set. "
+                // Log precedence when both limits are explicitly set
+                if (maxDuration != null && config.isNumberOfOperationsExplicitlySet()) {
+                    logger.warn("Both maxRunningTimeDuration ({}) and numberOfOperations ({}) are explicitly set. "
                         + "maxRunningTimeDuration takes precedence; numberOfOperations is ignored.",
                         maxDuration, numberOfOps);
                 }
@@ -387,6 +394,7 @@ public class BenchmarkOrchestrator {
                 }
 
                 AtomicLong completedCount = new AtomicLong(0);
+                AtomicLong errorCount = new AtomicLong(0);
                 int tenantCount = dispatchable.size();
 
                 source
@@ -395,13 +403,15 @@ public class BenchmarkOrchestrator {
                         Benchmark selected = dispatchable.get(tenantIndex);
                         long tenantLocalIndex = tenantCounters[tenantIndex].getAndIncrement();
                         return selected.performSingleOperation(tenantLocalIndex)
-                            .doOnTerminate(completedCount::incrementAndGet);
+                            .doOnSuccess(v -> completedCount.incrementAndGet())
+                            .doOnError(e -> errorCount.incrementAndGet());
                     }, concurrency)
                     .blockLast();
 
                 long endTime = System.currentTimeMillis();
-                logger.info("[DISPATCH] {} operations dispatched across {} tenants in {}s (cycle={})",
-                    completedCount.get(), tenantCount,
+                logger.info("[DISPATCH] {} operations completed ({} succeeded, {} failed) across {} tenants in {}s (cycle={})",
+                    completedCount.get() + errorCount.get(), completedCount.get(), errorCount.get(),
+                    tenantCount,
                     (int) ((endTime - workloadStartTime) / 1000), cycle);
             }
 

--- a/sdk/cosmos/azure-cosmos-benchmark/src/main/java/com/azure/cosmos/benchmark/BenchmarkOrchestrator.java
+++ b/sdk/cosmos/azure-cosmos-benchmark/src/main/java/com/azure/cosmos/benchmark/BenchmarkOrchestrator.java
@@ -21,9 +21,12 @@ import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
 import reactor.core.scheduler.Scheduler;
 import reactor.core.scheduler.Schedulers;
 
+import java.time.Duration;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.LinkedHashSet;
@@ -32,8 +35,10 @@ import java.util.Set;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
+import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
 
 /**
  * Benchmark orchestrator. Sets up infrastructure (metrics, reporters, system properties),
@@ -118,30 +123,31 @@ public class BenchmarkOrchestrator {
         int totalCycles = config.getCycles();
         List<TenantWorkloadConfig> tenants = config.getTenantWorkloads();
 
-        logger.info("Starting benchmark: {} cycles x {} tenants", totalCycles, tenants.size());
+        logger.info("Starting benchmark: {} cycles x {} tenants, concurrency={}, numberOfOperations={}",
+            totalCycles, tenants.size(), config.getConcurrency(), config.getNumberOfOperations());
         long startTime = System.currentTimeMillis();
 
         Scheduler benchmarkScheduler = Schedulers.parallel();
 
-        AtomicInteger threadCounter = new AtomicInteger(0);
-        ExecutorService executor = Executors.newFixedThreadPool(tenants.size(), r -> {
-            Thread t = new Thread(r, "tenant-worker-" + threadCounter.getAndIncrement());
-            t.setDaemon(false);
-            return t;
-        });
+        // Dedicated scheduler for sync benchmark operations (SyncBenchmark subclasses).
+        // Sized to the orchestrator concurrency to avoid becoming a bottleneck.
+        ExecutorService syncExecutorService = Executors.newFixedThreadPool(
+            Math.min(config.getConcurrency(), Runtime.getRuntime().availableProcessors() * 4),
+            r -> {
+                Thread t = new Thread(r, "sync-dispatch-" + Thread.currentThread().getId());
+                t.setDaemon(true);
+                return t;
+            });
+        Scheduler syncScheduler = Schedulers.fromExecutorService(syncExecutorService, "sync-dispatch");
 
         try {
             for (int cycle = 1; cycle <= totalCycles; cycle++) {
                 logger.info("[LIFECYCLE] CYCLE_START cycle={} timestamp={}", cycle, Instant.now());
 
                 // --- Fresh per-cycle metrics infrastructure ---
-                // Each cycle gets its own registry + reporter. The Cosmos SDK calls
-                // registry.clear() + registry.close() when a CosmosClient is destroyed,
-                // so we give it a disposable registry that we flush before shutdown.
                 CompositeMeterRegistry cycleRegistry = new CompositeMeterRegistry();
                 cycleRegistry.add(loggingRegistry);
 
-                // Netty HTTP connection pool metrics
                 boolean addedToGlobal = false;
                 if (config.isEnableNettyHttpMetrics()) {
                     Metrics.addRegistry(cycleRegistry);
@@ -168,14 +174,12 @@ public class BenchmarkOrchestrator {
                                 SimpleMeterRegistry cosmosSimpleRegistry = new SimpleMeterRegistry();
                                 cycleRegistry.add(cosmosSimpleRegistry);
                                 Set<String> ops = new LinkedHashSet<>();
-                                int totalConcurrency = 0;
                                 for (TenantWorkloadConfig t : tenants) {
                                     ops.add(t.getOperation() != null ? t.getOperation() : "Unknown");
-                                    totalConcurrency += t.getConcurrency();
                                 }
                                 cosmosReporter = CosmosMetricsReporter.create(
                                     cosmosSimpleRegistry, config.getCosmosReporterConfig(),
-                                    String.join("+", ops), totalConcurrency);
+                                    String.join("+", ops), config.getConcurrency());
                                 cosmosReporter.start(config.getPrintingInterval(), TimeUnit.SECONDS);
                                 break;
 
@@ -202,14 +206,22 @@ public class BenchmarkOrchestrator {
 
                     // 2. Create clients (constructors perform data ingestion)
                     List<Benchmark> benchmarks = createBenchmarks(config, benchmarkScheduler);
+
+                    // Inject sync dispatch scheduler into sync benchmarks
+                    for (Benchmark b : benchmarks) {
+                        if (b instanceof SyncBenchmark) {
+                            ((SyncBenchmark<?>) b).setSyncDispatchScheduler(syncScheduler);
+                        }
+                    }
+
                     logger.info("[LIFECYCLE] POST_CREATE cycle={} clients={} timestamp={}",
                         cycle, benchmarks.size(), Instant.now());
 
                     // 3. Cool-down: wait for CPU to settle after data ingestion before measuring workload
                     CpuMonitor.awaitCoolDown(baselineCpu);
 
-                    // 4. Run workload in parallel
-                    runWorkload(benchmarks, cycle, executor);
+                    // 4. Run workload — orchestrator dispatches operations across tenants
+                    runWorkload(benchmarks, cycle, config);
                     logger.info("[LIFECYCLE] POST_WORKLOAD cycle={} timestamp={}", cycle, Instant.now());
 
                     // 5. Flush reporters before shutdown destroys the registry
@@ -236,7 +248,6 @@ public class BenchmarkOrchestrator {
                         appInsightsRegistry = null;
                     }
                 } finally {
-                    // Ensure cleanup even if an exception occurred mid-cycle
                     if (csvReporter != null) {
                         try { csvReporter.stop(); } catch (Exception e) { /* already stopped or best-effort */ }
                     }
@@ -268,19 +279,15 @@ public class BenchmarkOrchestrator {
                 logger.info("[LIFECYCLE] POST_SETTLE cycle={} timestamp={}", cycle, Instant.now());
             }
         } finally {
-            logger.info("[LIFECYCLE] Shutting down executor...");
-            executor.shutdown();
+            logger.info("[LIFECYCLE] Shutting down sync dispatch scheduler...");
+            syncScheduler.dispose();
+            syncExecutorService.shutdown();
             try {
-                if (!executor.awaitTermination(60, TimeUnit.SECONDS)) {
-                    logger.warn("Executor did not terminate within the timeout");
-                    executor.shutdownNow();
-                    if (!executor.awaitTermination(60, TimeUnit.SECONDS)) {
-                        logger.error("Executor did not terminate after shutdownNow");
-                    }
+                if (!syncExecutorService.awaitTermination(60, TimeUnit.SECONDS)) {
+                    syncExecutorService.shutdownNow();
                 }
             } catch (InterruptedException e) {
-                logger.warn("Interrupted while awaiting executor termination", e);
-                executor.shutdownNow();
+                syncExecutorService.shutdownNow();
                 Thread.currentThread().interrupt();
             }
         }
@@ -298,20 +305,108 @@ public class BenchmarkOrchestrator {
         return benchmarks;
     }
 
-    private void runWorkload(List<Benchmark> benchmarks, int cycle, ExecutorService executor) throws Exception {
-        List<Future<?>> futures = new ArrayList<>();
-        final int currentCycle = cycle;
-        for (Benchmark benchmark : benchmarks) {
-            futures.add(executor.submit(() -> {
-                try {
-                    benchmark.run();
-                } catch (Exception e) {
-                    logger.error("Benchmark failed in cycle " + currentCycle, e);
-                }
-            }));
+    /**
+     * Run workload by dispatching operations from the orchestrator.
+     * Dispatchable benchmarks participate in a single Flux dispatch loop where the
+     * orchestrator randomly picks a tenant for each operation slot.
+     * Non-dispatchable benchmarks (e.g. LICtlWorkload) run via their own run() in a separate thread.
+     */
+    private void runWorkload(List<Benchmark> benchmarks, int cycle, BenchmarkConfig config) throws Exception {
+        // Separate dispatchable from non-dispatchable benchmarks
+        List<Benchmark> dispatchable = new ArrayList<>();
+        List<Benchmark> nonDispatchable = new ArrayList<>();
+        for (Benchmark b : benchmarks) {
+            if (b.isDispatchable()) {
+                dispatchable.add(b);
+            } else {
+                nonDispatchable.add(b);
+            }
         }
-        for (Future<?> f : futures) {
+
+        // Start non-dispatchable benchmarks in their own threads
+        ExecutorService legacyExecutor = null;
+        List<Future<?>> legacyFutures = new ArrayList<>();
+        if (!nonDispatchable.isEmpty()) {
+            logger.info("Running {} non-dispatchable benchmark(s) in legacy mode", nonDispatchable.size());
+            legacyExecutor = Executors.newFixedThreadPool(nonDispatchable.size());
+            final int currentCycle = cycle;
+            for (Benchmark benchmark : nonDispatchable) {
+                legacyFutures.add(legacyExecutor.submit(() -> {
+                    try {
+                        benchmark.run();
+                    } catch (Exception e) {
+                        logger.error("Non-dispatchable benchmark failed in cycle " + currentCycle, e);
+                    }
+                }));
+            }
+        }
+
+        // Dispatch operations across dispatchable benchmarks
+        if (!dispatchable.isEmpty()) {
+            int concurrency = config.getConcurrency();
+            long numberOfOps = config.getNumberOfOperations();
+            Duration maxDuration = config.getMaxRunningTimeDurationParsed();
+            long workloadStartTime = System.currentTimeMillis();
+
+            // Per-tenant operation counters for tenant-local indexing
+            AtomicLong[] tenantCounters = new AtomicLong[dispatchable.size()];
+            for (int i = 0; i < tenantCounters.length; i++) {
+                tenantCounters[i] = new AtomicLong(0);
+            }
+
+            Flux<Long> source;
+            if (maxDuration != null) {
+                final long deadline = workloadStartTime + maxDuration.toMillis();
+                source = Flux.generate(
+                    AtomicLong::new,
+                    (state, sink) -> {
+                        if (System.currentTimeMillis() < deadline) {
+                            sink.next(state.getAndIncrement());
+                        } else {
+                            sink.complete();
+                        }
+                        return state;
+                    });
+            } else {
+                source = Flux.generate(
+                    AtomicLong::new,
+                    (state, sink) -> {
+                        long current = state.getAndIncrement();
+                        if (current < numberOfOps) {
+                            sink.next(current);
+                        } else {
+                            sink.complete();
+                        }
+                        return state;
+                    });
+            }
+
+            AtomicLong completedCount = new AtomicLong(0);
+            int tenantCount = dispatchable.size();
+
+            source
+                .flatMap(globalIndex -> {
+                    int tenantIndex = ThreadLocalRandom.current().nextInt(tenantCount);
+                    Benchmark selected = dispatchable.get(tenantIndex);
+                    long tenantLocalIndex = tenantCounters[tenantIndex].getAndIncrement();
+                    return selected.performSingleOperation(tenantLocalIndex)
+                        .doOnTerminate(completedCount::incrementAndGet);
+                }, concurrency)
+                .blockLast();
+
+            long endTime = System.currentTimeMillis();
+            logger.info("[DISPATCH] {} operations dispatched across {} tenants in {}s (cycle={})",
+                completedCount.get(), tenantCount,
+                (int) ((endTime - workloadStartTime) / 1000), cycle);
+        }
+
+        // Wait for non-dispatchable benchmarks to finish
+        for (Future<?> f : legacyFutures) {
             f.get();
+        }
+        if (legacyExecutor != null) {
+            legacyExecutor.shutdown();
+            legacyExecutor.awaitTermination(60, TimeUnit.SECONDS);
         }
     }
 

--- a/sdk/cosmos/azure-cosmos-benchmark/src/main/java/com/azure/cosmos/benchmark/BenchmarkOrchestrator.java
+++ b/sdk/cosmos/azure-cosmos-benchmark/src/main/java/com/azure/cosmos/benchmark/BenchmarkOrchestrator.java
@@ -130,7 +130,12 @@ public class BenchmarkOrchestrator {
         Scheduler benchmarkScheduler = Schedulers.parallel();
 
         // Dedicated scheduler for sync benchmark operations (SyncBenchmark subclasses).
-        // Sized to the orchestrator concurrency to avoid becoming a bottleneck.
+        // Capped at availableProcessors * 4 as a safety measure to prevent thread explosion.
+        // Sync benchmarks perform blocking I/O, so this cap may bottleneck throughput compared
+        // to async dispatch (e.g., 16 threads on a 4-core machine vs 1000 async concurrency).
+        // This trade-off is intentional — unbounded sync thread pools risk OOM and context-switch
+        // overhead. Consider increasing the multiplier or making it configurable if sync
+        // throughput needs to match async levels.
         AtomicInteger syncThreadCounter = new AtomicInteger(0);
         ExecutorService syncExecutorService = Executors.newFixedThreadPool(
             Math.min(config.getConcurrency(), Runtime.getRuntime().availableProcessors() * 4),
@@ -326,6 +331,7 @@ public class BenchmarkOrchestrator {
         // Start non-dispatchable benchmarks in their own threads
         ExecutorService legacyExecutor = null;
         List<Future<?>> legacyFutures = new ArrayList<>();
+        AtomicInteger nonDispatchableFailures = new AtomicInteger(0);
         if (!nonDispatchable.isEmpty()) {
             logger.info("Running {} non-dispatchable benchmark(s) in legacy mode", nonDispatchable.size());
             AtomicInteger legacyCounter = new AtomicInteger(0);
@@ -335,7 +341,6 @@ public class BenchmarkOrchestrator {
                 return t;
             });
             final int currentCycle = cycle;
-            AtomicInteger nonDispatchableFailures = new AtomicInteger(0);
             for (Benchmark benchmark : nonDispatchable) {
                 legacyFutures.add(legacyExecutor.submit(() -> {
                     try {
@@ -371,12 +376,13 @@ public class BenchmarkOrchestrator {
 
                 Flux<Long> source;
                 if (maxDuration != null) {
-                    final long deadline = workloadStartTime + maxDuration.toMillis();
+                    // Use monotonic nanoTime to avoid wall-clock skew from NTP adjustments
+                    final long deadlineNanos = System.nanoTime() + maxDuration.toNanos();
                     source = Flux.generate(
-                        AtomicLong::new,
+                        () -> new long[]{0},
                         (state, sink) -> {
-                            if (System.currentTimeMillis() < deadline) {
-                                sink.next(state.getAndIncrement());
+                            if (System.nanoTime() < deadlineNanos) {
+                                sink.next(state[0]++);
                             } else {
                                 sink.complete();
                             }
@@ -384,9 +390,9 @@ public class BenchmarkOrchestrator {
                         });
                 } else {
                     source = Flux.generate(
-                        AtomicLong::new,
+                        () -> new long[]{0},
                         (state, sink) -> {
-                            long current = state.getAndIncrement();
+                            long current = state[0]++;
                             if (current < numberOfOps) {
                                 sink.next(current);
                             } else {
@@ -422,6 +428,10 @@ public class BenchmarkOrchestrator {
             // Wait for non-dispatchable benchmarks to finish
             for (Future<?> f : legacyFutures) {
                 f.get();
+            }
+            if (!nonDispatchable.isEmpty() && nonDispatchableFailures.get() > 0) {
+                logger.error("{} non-dispatchable benchmark(s) failed in cycle {}",
+                    nonDispatchableFailures.get(), cycle);
             }
         } finally {
             if (legacyExecutor != null) {

--- a/sdk/cosmos/azure-cosmos-benchmark/src/main/java/com/azure/cosmos/benchmark/BenchmarkOrchestrator.java
+++ b/sdk/cosmos/azure-cosmos-benchmark/src/main/java/com/azure/cosmos/benchmark/BenchmarkOrchestrator.java
@@ -136,9 +136,10 @@ public class BenchmarkOrchestrator {
         // This trade-off is intentional — unbounded sync thread pools risk OOM and context-switch
         // overhead. For high-concurrency sync scenarios, consider adding a syncDispatchMultiplier
         // config field to BenchmarkConfig to allow per-run tuning of this cap.
+        int effectiveSyncPoolSize = Math.min(config.getConcurrency(), Runtime.getRuntime().availableProcessors() * 4);
         AtomicInteger syncThreadCounter = new AtomicInteger(0);
         ExecutorService syncExecutorService = Executors.newFixedThreadPool(
-            Math.min(config.getConcurrency(), Runtime.getRuntime().availableProcessors() * 4),
+            effectiveSyncPoolSize,
             r -> {
                 Thread t = new Thread(r, "sync-dispatch-" + syncThreadCounter.getAndIncrement());
                 t.setDaemon(true);
@@ -146,7 +147,6 @@ public class BenchmarkOrchestrator {
             });
         Scheduler syncScheduler = Schedulers.fromExecutorService(syncExecutorService, "sync-dispatch");
 
-        int effectiveSyncPoolSize = Math.min(config.getConcurrency(), Runtime.getRuntime().availableProcessors() * 4);
         if (effectiveSyncPoolSize < config.getConcurrency()) {
             logger.info("Sync dispatch pool: {} threads (capped from concurrency={}). "
                 + "Async benchmarks use full concurrency; sync throughput may be lower.",
@@ -331,6 +331,22 @@ public class BenchmarkOrchestrator {
      * (e.g., a weight field in TenantWorkloadConfig) for reproducing realistic traffic ratios.</p>
      */
     private void runWorkload(List<Benchmark> benchmarks, int cycle, BenchmarkConfig config) throws Exception {
+        // Warn if any dispatchable tenant specifies concurrency/numberOfOperations,
+        // which are ignored in orchestrator dispatch mode.
+        for (int i = 0; i < benchmarks.size(); i++) {
+            if (benchmarks.get(i).isDispatchable()) {
+                TenantWorkloadConfig tenantCfg = config.getTenantWorkloads().get(i);
+                if (tenantCfg.isConcurrencyExplicitlySet() || tenantCfg.isNumberOfOperationsExplicitlySet()) {
+                    logger.warn("Tenant '{}' has explicitly-set {} which is ignored in orchestrator dispatch mode. "
+                        + "Use orchestrator-level concurrency/numberOfOperations in BenchmarkConfig instead.",
+                        tenantCfg.getId() != null ? tenantCfg.getId() : ("tenant-" + i),
+                        (tenantCfg.isConcurrencyExplicitlySet() ? "concurrency=" + tenantCfg.getConcurrency() : "")
+                            + (tenantCfg.isConcurrencyExplicitlySet() && tenantCfg.isNumberOfOperationsExplicitlySet() ? ", " : "")
+                            + (tenantCfg.isNumberOfOperationsExplicitlySet() ? "numberOfOperations=" + tenantCfg.getNumberOfOperations() : ""));
+                }
+            }
+        }
+
         // Separate dispatchable from non-dispatchable benchmarks
         List<Benchmark> dispatchable = new ArrayList<>();
         List<Benchmark> nonDispatchable = new ArrayList<>();

--- a/sdk/cosmos/azure-cosmos-benchmark/src/main/java/com/azure/cosmos/benchmark/BenchmarkOrchestrator.java
+++ b/sdk/cosmos/azure-cosmos-benchmark/src/main/java/com/azure/cosmos/benchmark/BenchmarkOrchestrator.java
@@ -146,6 +146,15 @@ public class BenchmarkOrchestrator {
             });
         Scheduler syncScheduler = Schedulers.fromExecutorService(syncExecutorService, "sync-dispatch");
 
+        int effectiveSyncPoolSize = Math.min(config.getConcurrency(), Runtime.getRuntime().availableProcessors() * 4);
+        if (effectiveSyncPoolSize < config.getConcurrency()) {
+            logger.info("Sync dispatch pool: {} threads (capped from concurrency={}). "
+                + "Async benchmarks use full concurrency; sync throughput may be lower.",
+                effectiveSyncPoolSize, config.getConcurrency());
+        } else {
+            logger.info("Sync dispatch pool: {} threads", effectiveSyncPoolSize);
+        }
+
         try {
             for (int cycle = 1; cycle <= totalCycles; cycle++) {
                 logger.info("[LIFECYCLE] CYCLE_START cycle={} timestamp={}", cycle, Instant.now());
@@ -283,9 +292,14 @@ public class BenchmarkOrchestrator {
             syncExecutorService.shutdown();
             try {
                 if (!syncExecutorService.awaitTermination(60, TimeUnit.SECONDS)) {
+                    logger.warn("Sync dispatch pool did not terminate within 60s, forcing shutdown");
                     syncExecutorService.shutdownNow();
+                    if (!syncExecutorService.awaitTermination(10, TimeUnit.SECONDS)) {
+                        logger.error("Sync dispatch pool did not terminate after shutdownNow");
+                    }
                 }
             } catch (InterruptedException e) {
+                logger.error("Interrupted while waiting for sync dispatch pool termination", e);
                 syncExecutorService.shutdownNow();
                 Thread.currentThread().interrupt();
             }
@@ -432,6 +446,8 @@ public class BenchmarkOrchestrator {
             if (!nonDispatchable.isEmpty() && nonDispatchableFailures.get() > 0) {
                 logger.error("{} non-dispatchable benchmark(s) failed in cycle {}",
                     nonDispatchableFailures.get(), cycle);
+                throw new RuntimeException(
+                    nonDispatchableFailures.get() + " non-dispatchable benchmark(s) failed in cycle " + cycle);
             }
         } finally {
             if (legacyExecutor != null) {

--- a/sdk/cosmos/azure-cosmos-benchmark/src/main/java/com/azure/cosmos/benchmark/BenchmarkOrchestrator.java
+++ b/sdk/cosmos/azure-cosmos-benchmark/src/main/java/com/azure/cosmos/benchmark/BenchmarkOrchestrator.java
@@ -131,10 +131,11 @@ public class BenchmarkOrchestrator {
 
         // Dedicated scheduler for sync benchmark operations (SyncBenchmark subclasses).
         // Sized to the orchestrator concurrency to avoid becoming a bottleneck.
+        AtomicInteger syncThreadCounter = new AtomicInteger(0);
         ExecutorService syncExecutorService = Executors.newFixedThreadPool(
             Math.min(config.getConcurrency(), Runtime.getRuntime().availableProcessors() * 4),
             r -> {
-                Thread t = new Thread(r, "sync-dispatch-" + Thread.currentThread().getId());
+                Thread t = new Thread(r, "sync-dispatch-" + syncThreadCounter.getAndIncrement());
                 t.setDaemon(true);
                 return t;
             });
@@ -205,14 +206,7 @@ public class BenchmarkOrchestrator {
                     double baselineCpu = CpuMonitor.captureProcessCpuLoad();
 
                     // 2. Create clients (constructors perform data ingestion)
-                    List<Benchmark> benchmarks = createBenchmarks(config, benchmarkScheduler);
-
-                    // Inject sync dispatch scheduler into sync benchmarks
-                    for (Benchmark b : benchmarks) {
-                        if (b instanceof SyncBenchmark) {
-                            ((SyncBenchmark<?>) b).setSyncDispatchScheduler(syncScheduler);
-                        }
-                    }
+                    List<Benchmark> benchmarks = createBenchmarks(config, benchmarkScheduler, syncScheduler);
 
                     logger.info("[LIFECYCLE] POST_CREATE cycle={} clients={} timestamp={}",
                         cycle, benchmarks.size(), Instant.now());
@@ -297,10 +291,10 @@ public class BenchmarkOrchestrator {
             totalCycles, durationSec, Instant.now());
     }
 
-    private List<Benchmark> createBenchmarks(BenchmarkConfig config, Scheduler scheduler) throws Exception {
+    private List<Benchmark> createBenchmarks(BenchmarkConfig config, Scheduler scheduler, Scheduler syncScheduler) throws Exception {
         List<Benchmark> benchmarks = new ArrayList<>();
         for (TenantWorkloadConfig tenant : config.getTenantWorkloads()) {
-            benchmarks.add(createBenchmarkForOperation(tenant, scheduler));
+            benchmarks.add(createBenchmarkForOperation(tenant, scheduler, syncScheduler));
         }
         return benchmarks;
     }
@@ -308,7 +302,10 @@ public class BenchmarkOrchestrator {
     /**
      * Run workload by dispatching operations from the orchestrator.
      * Dispatchable benchmarks participate in a single Flux dispatch loop where the
-     * orchestrator randomly picks a tenant for each operation slot.
+     * orchestrator randomly picks a tenant for each operation slot. Tenant selection
+     * is uniform random; per-tenant concurrency and numberOfOperations settings in
+     * {@link TenantWorkloadConfig} are not used during orchestrator dispatch — the
+     * orchestrator-level settings in {@link BenchmarkConfig} control the total workload.
      * Non-dispatchable benchmarks (e.g. LICtlWorkload) run via their own run() in a separate thread.
      */
     private void runWorkload(List<Benchmark> benchmarks, int cycle, BenchmarkConfig config) throws Exception {
@@ -341,72 +338,86 @@ public class BenchmarkOrchestrator {
             }
         }
 
-        // Dispatch operations across dispatchable benchmarks
-        if (!dispatchable.isEmpty()) {
-            int concurrency = config.getConcurrency();
-            long numberOfOps = config.getNumberOfOperations();
-            Duration maxDuration = config.getMaxRunningTimeDurationParsed();
-            long workloadStartTime = System.currentTimeMillis();
+        try {
+            // Dispatch operations across dispatchable benchmarks
+            if (!dispatchable.isEmpty()) {
+                int concurrency = config.getConcurrency();
+                long numberOfOps = config.getNumberOfOperations();
+                Duration maxDuration = config.getMaxRunningTimeDurationParsed();
+                long workloadStartTime = System.currentTimeMillis();
 
-            // Per-tenant operation counters for tenant-local indexing
-            AtomicLong[] tenantCounters = new AtomicLong[dispatchable.size()];
-            for (int i = 0; i < tenantCounters.length; i++) {
-                tenantCounters[i] = new AtomicLong(0);
+                // Log precedence when both limits are set
+                if (maxDuration != null && numberOfOps > 0) {
+                    logger.warn("Both maxRunningTimeDuration ({}) and numberOfOperations ({}) are set. "
+                        + "maxRunningTimeDuration takes precedence; numberOfOperations is ignored.",
+                        maxDuration, numberOfOps);
+                }
+
+                // Per-tenant operation counters for tenant-local indexing
+                AtomicLong[] tenantCounters = new AtomicLong[dispatchable.size()];
+                for (int i = 0; i < tenantCounters.length; i++) {
+                    tenantCounters[i] = new AtomicLong(0);
+                }
+
+                Flux<Long> source;
+                if (maxDuration != null) {
+                    final long deadline = workloadStartTime + maxDuration.toMillis();
+                    source = Flux.generate(
+                        AtomicLong::new,
+                        (state, sink) -> {
+                            if (System.currentTimeMillis() < deadline) {
+                                sink.next(state.getAndIncrement());
+                            } else {
+                                sink.complete();
+                            }
+                            return state;
+                        });
+                } else {
+                    source = Flux.generate(
+                        AtomicLong::new,
+                        (state, sink) -> {
+                            long current = state.getAndIncrement();
+                            if (current < numberOfOps) {
+                                sink.next(current);
+                            } else {
+                                sink.complete();
+                            }
+                            return state;
+                        });
+                }
+
+                AtomicLong completedCount = new AtomicLong(0);
+                int tenantCount = dispatchable.size();
+
+                source
+                    .flatMap(globalIndex -> {
+                        int tenantIndex = ThreadLocalRandom.current().nextInt(tenantCount);
+                        Benchmark selected = dispatchable.get(tenantIndex);
+                        long tenantLocalIndex = tenantCounters[tenantIndex].getAndIncrement();
+                        return selected.performSingleOperation(tenantLocalIndex)
+                            .doOnTerminate(completedCount::incrementAndGet);
+                    }, concurrency)
+                    .blockLast();
+
+                long endTime = System.currentTimeMillis();
+                logger.info("[DISPATCH] {} operations dispatched across {} tenants in {}s (cycle={})",
+                    completedCount.get(), tenantCount,
+                    (int) ((endTime - workloadStartTime) / 1000), cycle);
             }
 
-            Flux<Long> source;
-            if (maxDuration != null) {
-                final long deadline = workloadStartTime + maxDuration.toMillis();
-                source = Flux.generate(
-                    AtomicLong::new,
-                    (state, sink) -> {
-                        if (System.currentTimeMillis() < deadline) {
-                            sink.next(state.getAndIncrement());
-                        } else {
-                            sink.complete();
-                        }
-                        return state;
-                    });
-            } else {
-                source = Flux.generate(
-                    AtomicLong::new,
-                    (state, sink) -> {
-                        long current = state.getAndIncrement();
-                        if (current < numberOfOps) {
-                            sink.next(current);
-                        } else {
-                            sink.complete();
-                        }
-                        return state;
-                    });
+            // Wait for non-dispatchable benchmarks to finish
+            for (Future<?> f : legacyFutures) {
+                f.get();
             }
-
-            AtomicLong completedCount = new AtomicLong(0);
-            int tenantCount = dispatchable.size();
-
-            source
-                .flatMap(globalIndex -> {
-                    int tenantIndex = ThreadLocalRandom.current().nextInt(tenantCount);
-                    Benchmark selected = dispatchable.get(tenantIndex);
-                    long tenantLocalIndex = tenantCounters[tenantIndex].getAndIncrement();
-                    return selected.performSingleOperation(tenantLocalIndex)
-                        .doOnTerminate(completedCount::incrementAndGet);
-                }, concurrency)
-                .blockLast();
-
-            long endTime = System.currentTimeMillis();
-            logger.info("[DISPATCH] {} operations dispatched across {} tenants in {}s (cycle={})",
-                completedCount.get(), tenantCount,
-                (int) ((endTime - workloadStartTime) / 1000), cycle);
-        }
-
-        // Wait for non-dispatchable benchmarks to finish
-        for (Future<?> f : legacyFutures) {
-            f.get();
-        }
-        if (legacyExecutor != null) {
-            legacyExecutor.shutdown();
-            legacyExecutor.awaitTermination(60, TimeUnit.SECONDS);
+        } finally {
+            if (legacyExecutor != null) {
+                legacyExecutor.shutdownNow();
+                try {
+                    legacyExecutor.awaitTermination(60, TimeUnit.SECONDS);
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                }
+            }
         }
     }
 
@@ -447,14 +458,14 @@ public class BenchmarkOrchestrator {
 
     // ======== Benchmark factory ========
 
-    private Benchmark createBenchmarkForOperation(TenantWorkloadConfig cfg, Scheduler scheduler) throws Exception {
+    private Benchmark createBenchmarkForOperation(TenantWorkloadConfig cfg, Scheduler scheduler, Scheduler syncScheduler) throws Exception {
         // Sync benchmarks
         if (cfg.isSync()) {
             switch (cfg.getOperationType()) {
                 case ReadThroughput:
-                    return new SyncReadBenchmark(cfg);
+                    return new SyncReadBenchmark(cfg, syncScheduler);
                 case WriteThroughput:
-                    return new SyncWriteBenchmark(cfg);
+                    return new SyncWriteBenchmark(cfg, syncScheduler);
                 default:
                     throw new IllegalArgumentException(
                         "Sync mode is not supported for operation: " + cfg.getOperationType());

--- a/sdk/cosmos/azure-cosmos-benchmark/src/main/java/com/azure/cosmos/benchmark/BenchmarkOrchestrator.java
+++ b/sdk/cosmos/azure-cosmos-benchmark/src/main/java/com/azure/cosmos/benchmark/BenchmarkOrchestrator.java
@@ -328,17 +328,20 @@ public class BenchmarkOrchestrator {
         List<Future<?>> legacyFutures = new ArrayList<>();
         if (!nonDispatchable.isEmpty()) {
             logger.info("Running {} non-dispatchable benchmark(s) in legacy mode", nonDispatchable.size());
+            AtomicInteger legacyCounter = new AtomicInteger(0);
             legacyExecutor = Executors.newFixedThreadPool(nonDispatchable.size(), r -> {
-                Thread t = new Thread(r, "legacy-dispatch-" + r.hashCode());
+                Thread t = new Thread(r, "legacy-dispatch-" + legacyCounter.getAndIncrement());
                 t.setDaemon(true);
                 return t;
             });
             final int currentCycle = cycle;
+            AtomicInteger nonDispatchableFailures = new AtomicInteger(0);
             for (Benchmark benchmark : nonDispatchable) {
                 legacyFutures.add(legacyExecutor.submit(() -> {
                     try {
                         benchmark.run();
                     } catch (Exception e) {
+                        nonDispatchableFailures.incrementAndGet();
                         logger.error("Non-dispatchable benchmark failed in cycle " + currentCycle, e);
                     }
                 }));
@@ -404,7 +407,8 @@ public class BenchmarkOrchestrator {
                         long tenantLocalIndex = tenantCounters[tenantIndex].getAndIncrement();
                         return selected.performSingleOperation(tenantLocalIndex)
                             .doOnSuccess(v -> completedCount.incrementAndGet())
-                            .doOnError(e -> errorCount.incrementAndGet());
+                            .doOnError(e -> errorCount.incrementAndGet())
+                            .onErrorResume(e -> Mono.empty());
                     }, concurrency)
                     .blockLast();
 

--- a/sdk/cosmos/azure-cosmos-benchmark/src/main/java/com/azure/cosmos/benchmark/BenchmarkOrchestrator.java
+++ b/sdk/cosmos/azure-cosmos-benchmark/src/main/java/com/azure/cosmos/benchmark/BenchmarkOrchestrator.java
@@ -134,8 +134,8 @@ public class BenchmarkOrchestrator {
         // Sync benchmarks perform blocking I/O, so this cap may bottleneck throughput compared
         // to async dispatch (e.g., 16 threads on a 4-core machine vs 1000 async concurrency).
         // This trade-off is intentional — unbounded sync thread pools risk OOM and context-switch
-        // overhead. Consider increasing the multiplier or making it configurable if sync
-        // throughput needs to match async levels.
+        // overhead. For high-concurrency sync scenarios, consider adding a syncDispatchMultiplier
+        // config field to BenchmarkConfig to allow per-run tuning of this cap.
         AtomicInteger syncThreadCounter = new AtomicInteger(0);
         ExecutorService syncExecutorService = Executors.newFixedThreadPool(
             Math.min(config.getConcurrency(), Runtime.getRuntime().availableProcessors() * 4),
@@ -402,7 +402,7 @@ public class BenchmarkOrchestrator {
                         });
                 }
 
-                AtomicLong completedCount = new AtomicLong(0);
+                AtomicLong successCount = new AtomicLong(0);
                 AtomicLong errorCount = new AtomicLong(0);
                 int tenantCount = dispatchable.size();
 
@@ -412,7 +412,7 @@ public class BenchmarkOrchestrator {
                         Benchmark selected = dispatchable.get(tenantIndex);
                         long tenantLocalIndex = tenantCounters[tenantIndex].getAndIncrement();
                         return selected.performSingleOperation(tenantLocalIndex)
-                            .doOnSuccess(v -> completedCount.incrementAndGet())
+                            .doOnSuccess(v -> successCount.incrementAndGet())
                             .doOnError(e -> errorCount.incrementAndGet())
                             .onErrorResume(e -> Mono.empty());
                     }, concurrency)
@@ -420,7 +420,7 @@ public class BenchmarkOrchestrator {
 
                 long endTime = System.currentTimeMillis();
                 logger.info("[DISPATCH] {} operations completed ({} succeeded, {} failed) across {} tenants in {}s (cycle={})",
-                    completedCount.get() + errorCount.get(), completedCount.get(), errorCount.get(),
+                    successCount.get() + errorCount.get(), successCount.get(), errorCount.get(),
                     tenantCount,
                     (int) ((endTime - workloadStartTime) / 1000), cycle);
             }

--- a/sdk/cosmos/azure-cosmos-benchmark/src/main/java/com/azure/cosmos/benchmark/SyncBenchmark.java
+++ b/sdk/cosmos/azure-cosmos-benchmark/src/main/java/com/azure/cosmos/benchmark/SyncBenchmark.java
@@ -298,12 +298,11 @@ abstract class SyncBenchmark<T> implements Benchmark {
 
     @Override
     public Mono<?> performSingleOperation(long operationIndex) {
-        Scheduler scheduler = syncDispatchScheduler != null
-            ? syncDispatchScheduler
-            : Schedulers.boundedElastic();
+        java.util.Objects.requireNonNull(syncDispatchScheduler,
+            "syncDispatchScheduler must be set by the orchestrator before dispatch");
         return Benchmark.wrapDispatchCallbacks(
             Mono.fromCallable(() -> performWorkload(operationIndex))
-                .subscribeOn(scheduler),
+                .subscribeOn(syncDispatchScheduler),
             this::onSuccess, this::onError, logger);
     }
 

--- a/sdk/cosmos/azure-cosmos-benchmark/src/main/java/com/azure/cosmos/benchmark/SyncBenchmark.java
+++ b/sdk/cosmos/azure-cosmos-benchmark/src/main/java/com/azure/cosmos/benchmark/SyncBenchmark.java
@@ -245,8 +245,18 @@ abstract class SyncBenchmark<T> implements Benchmark {
                     docsToRead = createDocumentFutureList.stream().map(future -> getOrThrow(future)).collect(Collectors.toList());
                 } finally {
                     preCreateExecutor.shutdown();
+                    try {
+                        if (!preCreateExecutor.awaitTermination(60, TimeUnit.SECONDS)) {
+                            preCreateExecutor.shutdownNow();
+                        }
+                    } catch (InterruptedException e) {
+                        preCreateExecutor.shutdownNow();
+                        Thread.currentThread().interrupt();
+                    }
                 }
             } else {
+                // Write-only operations skip pre-creation; createDocumentFutureList is empty,
+                // so this evaluates to an empty list.
                 docsToRead = createDocumentFutureList.stream().map(future -> getOrThrow(future)).collect(Collectors.toList());
             }
 
@@ -288,24 +298,13 @@ abstract class SyncBenchmark<T> implements Benchmark {
 
     @Override
     public Mono<?> performSingleOperation(long operationIndex) {
-        // NOTE: This dispatch-wrapping pattern (subscribe + onSuccess + onError)
-        // mirrors AsyncBenchmark and AsyncEncryptionBenchmark (different packages).
-        // If modifying this logic, update those performSingleOperation() implementations too.
         Scheduler scheduler = syncDispatchScheduler != null
             ? syncDispatchScheduler
             : Schedulers.boundedElastic();
-        return Mono.fromCallable(() -> performWorkload(operationIndex))
-            .subscribeOn(scheduler)
-            .doOnSuccess(v -> SyncBenchmark.this.onSuccess())
-            .doOnError(e -> {
-                try {
-                    logger.error("Encountered failure {} on thread {}",
-                        e.getMessage(), Thread.currentThread().getName(), e);
-                    SyncBenchmark.this.onError(e);
-                } catch (Exception handlerEx) {
-                    logger.error("onError handler threw for original error: {}", e.getMessage(), handlerEx);
-                }
-            });
+        return Benchmark.wrapDispatchCallbacks(
+            Mono.fromCallable(() -> performWorkload(operationIndex))
+                .subscribeOn(scheduler),
+            this::onSuccess, this::onError, logger);
     }
 
     public void run() throws Exception {

--- a/sdk/cosmos/azure-cosmos-benchmark/src/main/java/com/azure/cosmos/benchmark/SyncBenchmark.java
+++ b/sdk/cosmos/azure-cosmos-benchmark/src/main/java/com/azure/cosmos/benchmark/SyncBenchmark.java
@@ -37,6 +37,10 @@ import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.BiFunction;
 import java.util.stream.Collectors;
 
+import reactor.core.publisher.Mono;
+import reactor.core.scheduler.Scheduler;
+import reactor.core.scheduler.Schedulers;
+
 abstract class SyncBenchmark<T> implements Benchmark {
 
     private static final ImplementationBridgeHelpers.CosmosClientBuilderHelper.CosmosClientBuilderAccessor clientBuilderAccessor
@@ -257,6 +261,32 @@ abstract class SyncBenchmark<T> implements Benchmark {
     }
 
     protected abstract T performWorkload(long i) throws Exception;
+
+    /**
+     * Scheduler for executing sync benchmark operations from the orchestrator dispatch loop.
+     * Set by the orchestrator before the workload starts.
+     */
+    private volatile Scheduler syncDispatchScheduler;
+
+    public void setSyncDispatchScheduler(Scheduler scheduler) {
+        this.syncDispatchScheduler = scheduler;
+    }
+
+    @Override
+    public Mono<?> performSingleOperation(long operationIndex) {
+        Scheduler scheduler = syncDispatchScheduler != null
+            ? syncDispatchScheduler
+            : Schedulers.boundedElastic();
+        return Mono.fromCallable(() -> performWorkload(operationIndex))
+            .subscribeOn(scheduler)
+            .doOnSuccess(v -> SyncBenchmark.this.onSuccess())
+            .doOnError(e -> {
+                logger.error("Encountered failure {} on thread {}",
+                    e.getMessage(), Thread.currentThread().getName(), e);
+                SyncBenchmark.this.onError(e);
+            })
+            .onErrorResume(e -> Mono.empty());
+    }
 
     public void run() throws Exception {
 

--- a/sdk/cosmos/azure-cosmos-benchmark/src/main/java/com/azure/cosmos/benchmark/SyncBenchmark.java
+++ b/sdk/cosmos/azure-cosmos-benchmark/src/main/java/com/azure/cosmos/benchmark/SyncBenchmark.java
@@ -46,7 +46,7 @@ abstract class SyncBenchmark<T> implements Benchmark {
     private static final ImplementationBridgeHelpers.CosmosClientBuilderHelper.CosmosClientBuilderAccessor clientBuilderAccessor
         = ImplementationBridgeHelpers.CosmosClientBuilderHelper.getCosmosClientBuilderAccessor();
 
-    private ExecutorService executorService;
+    private volatile ExecutorService executorService;
 
     private boolean databaseCreated;
     private boolean collectionCreated;
@@ -288,6 +288,9 @@ abstract class SyncBenchmark<T> implements Benchmark {
 
     @Override
     public Mono<?> performSingleOperation(long operationIndex) {
+        // NOTE: This dispatch-wrapping pattern (subscribe + onSuccess + onError)
+        // mirrors AsyncBenchmark and AsyncEncryptionBenchmark (different packages).
+        // If modifying this logic, update those performSingleOperation() implementations too.
         Scheduler scheduler = syncDispatchScheduler != null
             ? syncDispatchScheduler
             : Schedulers.boundedElastic();
@@ -298,8 +301,7 @@ abstract class SyncBenchmark<T> implements Benchmark {
                 logger.error("Encountered failure {} on thread {}",
                     e.getMessage(), Thread.currentThread().getName(), e);
                 SyncBenchmark.this.onError(e);
-            })
-            .onErrorResume(e -> Mono.empty());
+            });
     }
 
     public void run() throws Exception {

--- a/sdk/cosmos/azure-cosmos-benchmark/src/main/java/com/azure/cosmos/benchmark/SyncBenchmark.java
+++ b/sdk/cosmos/azure-cosmos-benchmark/src/main/java/com/azure/cosmos/benchmark/SyncBenchmark.java
@@ -72,9 +72,16 @@ abstract class SyncBenchmark<T> implements Benchmark {
         abstract public T apply(T o, Throwable throwable);
     }
 
-    SyncBenchmark(TenantWorkloadConfig workloadCfg) throws Exception {
+    /**
+     * Scheduler for executing sync benchmark operations from the orchestrator dispatch loop.
+     * Passed through the constructor by the orchestrator.
+     */
+    private final Scheduler syncDispatchScheduler;
+
+    SyncBenchmark(TenantWorkloadConfig workloadCfg, Scheduler syncDispatchScheduler) throws Exception {
         executorService = Executors.newFixedThreadPool(workloadCfg.getConcurrency());
         workloadConfig = workloadCfg;
+        this.syncDispatchScheduler = syncDispatchScheduler;
 
         boolean isManagedIdentityRequired = workloadCfg.isManagedIdentityRequired();
 
@@ -262,14 +269,9 @@ abstract class SyncBenchmark<T> implements Benchmark {
 
     protected abstract T performWorkload(long i) throws Exception;
 
-    /**
-     * Scheduler for executing sync benchmark operations from the orchestrator dispatch loop.
-     * Set by the orchestrator before the workload starts.
-     */
-    private volatile Scheduler syncDispatchScheduler;
-
-    public void setSyncDispatchScheduler(Scheduler scheduler) {
-        this.syncDispatchScheduler = scheduler;
+    @Override
+    public boolean isDispatchable() {
+        return true;
     }
 
     @Override

--- a/sdk/cosmos/azure-cosmos-benchmark/src/main/java/com/azure/cosmos/benchmark/SyncBenchmark.java
+++ b/sdk/cosmos/azure-cosmos-benchmark/src/main/java/com/azure/cosmos/benchmark/SyncBenchmark.java
@@ -340,7 +340,6 @@ abstract class SyncBenchmark<T> implements Benchmark {
 
                         logger.error("Encountered failure {} on thread {}" ,
                                      throwable.getMessage(), Thread.currentThread().getName(), throwable);
-                        concurrencyControlSemaphore.release();
                         SyncBenchmark.this.onError(throwable);
 
                         synchronized (count) {

--- a/sdk/cosmos/azure-cosmos-benchmark/src/main/java/com/azure/cosmos/benchmark/SyncBenchmark.java
+++ b/sdk/cosmos/azure-cosmos-benchmark/src/main/java/com/azure/cosmos/benchmark/SyncBenchmark.java
@@ -46,7 +46,7 @@ abstract class SyncBenchmark<T> implements Benchmark {
     private static final ImplementationBridgeHelpers.CosmosClientBuilderHelper.CosmosClientBuilderAccessor clientBuilderAccessor
         = ImplementationBridgeHelpers.CosmosClientBuilderHelper.getCosmosClientBuilderAccessor();
 
-    private final ExecutorService executorService;
+    private ExecutorService executorService;
 
     private boolean databaseCreated;
     private boolean collectionCreated;
@@ -79,7 +79,6 @@ abstract class SyncBenchmark<T> implements Benchmark {
     private final Scheduler syncDispatchScheduler;
 
     SyncBenchmark(TenantWorkloadConfig workloadCfg, Scheduler syncDispatchScheduler) throws Exception {
-        executorService = Executors.newFixedThreadPool(workloadCfg.getConcurrency());
         workloadConfig = workloadCfg;
         this.syncDispatchScheduler = syncDispatchScheduler;
 
@@ -186,60 +185,71 @@ abstract class SyncBenchmark<T> implements Benchmark {
 
             if (workloadCfg.getOperationType() != Operation.WriteThroughput
                     && workloadCfg.getOperationType() != Operation.ReadMyWrites) {
-                String dataFieldValue = RandomStringUtils.randomAlphabetic(workloadCfg.getDocumentDataFieldSize());
-                for (int i = 0; i < workloadCfg.getNumberOfPreCreatedDocuments(); i++) {
-                    String uuid = UUID.randomUUID().toString();
-                    PojoizedJson newDoc = BenchmarkHelper.generateDocument(uuid,
-                            dataFieldValue,
-                            partitionKey,
-                            workloadCfg.getDocumentDataFieldCount());
-                    CompletableFuture<PojoizedJson> futureResult = CompletableFuture.supplyAsync(() -> {
+                // Use a small temporary pool for document pre-creation only.
+                // The full executorService is lazily created in run() to avoid leaking
+                // a large thread pool when the orchestrator handles dispatch.
+                int preCreateThreads = Math.min(workloadCfg.getConcurrency(), 8);
+                ExecutorService preCreateExecutor = Executors.newFixedThreadPool(preCreateThreads);
+                try {
+                    String dataFieldValue = RandomStringUtils.randomAlphabetic(workloadCfg.getDocumentDataFieldSize());
+                    for (int i = 0; i < workloadCfg.getNumberOfPreCreatedDocuments(); i++) {
+                        String uuid = UUID.randomUUID().toString();
+                        PojoizedJson newDoc = BenchmarkHelper.generateDocument(uuid,
+                                dataFieldValue,
+                                partitionKey,
+                                workloadCfg.getDocumentDataFieldCount());
+                        CompletableFuture<PojoizedJson> futureResult = CompletableFuture.supplyAsync(() -> {
 
-                        int maxRetries = 5;
-                        Exception lastException = null;
-                        for (int attempt = 0; attempt <= maxRetries; attempt++) {
-                            try {
-                                CosmosItemResponse<PojoizedJson> itemResponse = cosmosContainer.createItem(newDoc);
-                                return toPojoizedJson(itemResponse);
-                            } catch (CosmosException ce) {
-                                lastException = ce;
-                                if (ce.getStatusCode() == 409) {
-                                    // conflict — document already exists, read it back
-                                    try {
-                                        return cosmosContainer.readItem(
-                                            uuid, new PartitionKey(uuid), PojoizedJson.class).getItem();
-                                    } catch (Exception readEx) {
-                                        throw propagate(readEx);
+                            int maxRetries = 5;
+                            Exception lastException = null;
+                            for (int attempt = 0; attempt <= maxRetries; attempt++) {
+                                try {
+                                    CosmosItemResponse<PojoizedJson> itemResponse = cosmosContainer.createItem(newDoc);
+                                    return toPojoizedJson(itemResponse);
+                                } catch (CosmosException ce) {
+                                    lastException = ce;
+                                    if (ce.getStatusCode() == 409) {
+                                        // conflict — document already exists, read it back
+                                        try {
+                                            return cosmosContainer.readItem(
+                                                uuid, new PartitionKey(uuid), PojoizedJson.class).getItem();
+                                        } catch (Exception readEx) {
+                                            throw propagate(readEx);
+                                        }
                                     }
-                                }
-                                int statusCode = ce.getStatusCode();
-                                boolean isTransient = statusCode == 408 || statusCode == 410
-                                    || statusCode == 429 || statusCode == 449
-                                    || statusCode == 500 || statusCode == 503;
-                                if (isTransient && attempt < maxRetries) {
-                                    try {
-                                        Thread.sleep(1000L * (attempt + 1));
-                                    } catch (InterruptedException ie) {
-                                        Thread.currentThread().interrupt();
-                                        throw propagate(ce);
+                                    int statusCode = ce.getStatusCode();
+                                    boolean isTransient = statusCode == 408 || statusCode == 410
+                                        || statusCode == 429 || statusCode == 449
+                                        || statusCode == 500 || statusCode == 503;
+                                    if (isTransient && attempt < maxRetries) {
+                                        try {
+                                            Thread.sleep(1000L * (attempt + 1));
+                                        } catch (InterruptedException ie) {
+                                            Thread.currentThread().interrupt();
+                                            throw propagate(ce);
+                                        }
+                                        continue;
                                     }
-                                    continue;
+                                    throw propagate(ce);
+                                } catch (Exception e) {
+                                    lastException = e;
+                                    throw propagate(e);
                                 }
-                                throw propagate(ce);
-                            } catch (Exception e) {
-                                lastException = e;
-                                throw propagate(e);
                             }
-                        }
-                        throw new RuntimeException("Exhausted retries for createItem", lastException);
+                            throw new RuntimeException("Exhausted retries for createItem", lastException);
 
-                    }, executorService);
+                        }, preCreateExecutor);
 
-                    createDocumentFutureList.add(futureResult);
+                        createDocumentFutureList.add(futureResult);
+                    }
+                    docsToRead = createDocumentFutureList.stream().map(future -> getOrThrow(future)).collect(Collectors.toList());
+                } finally {
+                    preCreateExecutor.shutdown();
                 }
+            } else {
+                docsToRead = createDocumentFutureList.stream().map(future -> getOrThrow(future)).collect(Collectors.toList());
             }
 
-            docsToRead = createDocumentFutureList.stream().map(future -> getOrThrow(future)).collect(Collectors.toList());
             init();
     }
 
@@ -258,7 +268,9 @@ abstract class SyncBenchmark<T> implements Benchmark {
         }
 
         benchmarkWorkloadClient.close();
-        executorService.shutdown();
+        if (executorService != null) {
+            executorService.shutdown();
+        }
     }
 
     protected void onSuccess() {
@@ -291,6 +303,11 @@ abstract class SyncBenchmark<T> implements Benchmark {
     }
 
     public void run() throws Exception {
+
+        // Lazily create the executor for standalone (non-dispatch) mode
+        if (executorService == null) {
+            executorService = Executors.newFixedThreadPool(workloadConfig.getConcurrency());
+        }
 
         long startTime = System.currentTimeMillis();
 

--- a/sdk/cosmos/azure-cosmos-benchmark/src/main/java/com/azure/cosmos/benchmark/SyncBenchmark.java
+++ b/sdk/cosmos/azure-cosmos-benchmark/src/main/java/com/azure/cosmos/benchmark/SyncBenchmark.java
@@ -298,17 +298,23 @@ abstract class SyncBenchmark<T> implements Benchmark {
             .subscribeOn(scheduler)
             .doOnSuccess(v -> SyncBenchmark.this.onSuccess())
             .doOnError(e -> {
-                logger.error("Encountered failure {} on thread {}",
-                    e.getMessage(), Thread.currentThread().getName(), e);
-                SyncBenchmark.this.onError(e);
+                try {
+                    logger.error("Encountered failure {} on thread {}",
+                        e.getMessage(), Thread.currentThread().getName(), e);
+                    SyncBenchmark.this.onError(e);
+                } catch (Exception handlerEx) {
+                    logger.error("onError handler threw for original error: {}", e.getMessage(), handlerEx);
+                }
             });
     }
 
     public void run() throws Exception {
 
         // Lazily create the executor for standalone (non-dispatch) mode
-        if (executorService == null) {
-            executorService = Executors.newFixedThreadPool(workloadConfig.getConcurrency());
+        synchronized (this) {
+            if (executorService == null) {
+                executorService = Executors.newFixedThreadPool(workloadConfig.getConcurrency());
+            }
         }
 
         long startTime = System.currentTimeMillis();

--- a/sdk/cosmos/azure-cosmos-benchmark/src/main/java/com/azure/cosmos/benchmark/SyncReadBenchmark.java
+++ b/sdk/cosmos/azure-cosmos-benchmark/src/main/java/com/azure/cosmos/benchmark/SyncReadBenchmark.java
@@ -8,11 +8,13 @@ import com.azure.cosmos.models.CosmosItemRequestOptions;
 import com.azure.cosmos.models.CosmosItemResponse;
 import com.azure.cosmos.models.PartitionKey;
 
+import reactor.core.scheduler.Scheduler;
+
 
 class SyncReadBenchmark extends SyncBenchmark<CosmosItemResponse> {
 
-    SyncReadBenchmark(TenantWorkloadConfig workloadCfg) throws Exception {
-        super(workloadCfg);
+    SyncReadBenchmark(TenantWorkloadConfig workloadCfg, Scheduler syncDispatchScheduler) throws Exception {
+        super(workloadCfg, syncDispatchScheduler);
     }
 
     @Override

--- a/sdk/cosmos/azure-cosmos-benchmark/src/main/java/com/azure/cosmos/benchmark/SyncWriteBenchmark.java
+++ b/sdk/cosmos/azure-cosmos-benchmark/src/main/java/com/azure/cosmos/benchmark/SyncWriteBenchmark.java
@@ -7,6 +7,8 @@ import com.azure.cosmos.models.CosmosItemResponse;
 import com.azure.cosmos.models.PartitionKey;
 import org.apache.commons.lang3.RandomStringUtils;
 
+import reactor.core.scheduler.Scheduler;
+
 
 import java.util.UUID;
 
@@ -15,8 +17,8 @@ class SyncWriteBenchmark extends SyncBenchmark<CosmosItemResponse> {
     private final String dataFieldValue;
     private final String uuid;
 
-    SyncWriteBenchmark(TenantWorkloadConfig workloadCfg) throws Exception {
-        super(workloadCfg);
+    SyncWriteBenchmark(TenantWorkloadConfig workloadCfg, Scheduler syncDispatchScheduler) throws Exception {
+        super(workloadCfg, syncDispatchScheduler);
 
         uuid = UUID.randomUUID().toString();
         dataFieldValue =

--- a/sdk/cosmos/azure-cosmos-benchmark/src/main/java/com/azure/cosmos/benchmark/TenantWorkloadConfig.java
+++ b/sdk/cosmos/azure-cosmos-benchmark/src/main/java/com/azure/cosmos/benchmark/TenantWorkloadConfig.java
@@ -252,7 +252,9 @@ public class TenantWorkloadConfig {
     }
 
     public int getConcurrency() { return concurrency != null ? concurrency : 1000; }
+    public boolean isConcurrencyExplicitlySet() { return concurrency != null; }
     public int getNumberOfOperations() { return numberOfOperations != null ? numberOfOperations : 100000; }
+    public boolean isNumberOfOperationsExplicitlySet() { return numberOfOperations != null; }
     public int getNumberOfPreCreatedDocuments() { return numberOfPreCreatedDocuments != null ? numberOfPreCreatedDocuments : 1000; }
     public int getThroughput() { return throughput != null ? throughput : 100000; }
     public int getDocumentDataFieldSize() { return documentDataFieldSize != null ? documentDataFieldSize : 20; }

--- a/sdk/cosmos/azure-cosmos-benchmark/src/main/java/com/azure/cosmos/benchmark/ctl/AsyncCtlWorkload.java
+++ b/sdk/cosmos/azure-cosmos-benchmark/src/main/java/com/azure/cosmos/benchmark/ctl/AsyncCtlWorkload.java
@@ -188,10 +188,19 @@ public class AsyncCtlWorkload implements Benchmark {
         // Intentionally omits onSuccess callback — consistent with run() which also
         // does not track per-operation success for CTL workloads.
         // NOTE: mirrors dispatch-wrapping pattern in AsyncBenchmark.performSingleOperation().
+        // Unlike AsyncBenchmark and AsyncEncryptionBenchmark, this class does not call
+        // onError(e) because CTL workloads have no per-operation error callback. Error
+        // counting is handled by the orchestrator's doOnError + errorCount.
         return selectAndPerformWorkload(operationIndex)
             .subscribeOn(benchmarkScheduler)
-            .doOnError(e -> logger.error("Encountered failure {} on thread {}",
-                e.getMessage(), Thread.currentThread().getName(), e));
+            .doOnError(e -> {
+                try {
+                    logger.error("Encountered failure {} on thread {}",
+                        e.getMessage(), Thread.currentThread().getName(), e);
+                } catch (Exception handlerEx) {
+                    logger.error("Error handler threw for original error: {}", e.getMessage(), handlerEx);
+                }
+            });
     }
 
     public void run() throws Exception {

--- a/sdk/cosmos/azure-cosmos-benchmark/src/main/java/com/azure/cosmos/benchmark/ctl/AsyncCtlWorkload.java
+++ b/sdk/cosmos/azure-cosmos-benchmark/src/main/java/com/azure/cosmos/benchmark/ctl/AsyncCtlWorkload.java
@@ -179,7 +179,14 @@ public class AsyncCtlWorkload implements Benchmark {
     }
 
     @Override
+    public boolean isDispatchable() {
+        return true;
+    }
+
+    @Override
     public Mono<?> performSingleOperation(long operationIndex) {
+        // Intentionally omits onSuccess callback — consistent with run() which also
+        // does not track per-operation success for CTL workloads.
         return selectAndPerformWorkload(operationIndex)
             .subscribeOn(benchmarkScheduler)
             .doOnError(e -> logger.error("CTL failure on thread {}: {}",

--- a/sdk/cosmos/azure-cosmos-benchmark/src/main/java/com/azure/cosmos/benchmark/ctl/AsyncCtlWorkload.java
+++ b/sdk/cosmos/azure-cosmos-benchmark/src/main/java/com/azure/cosmos/benchmark/ctl/AsyncCtlWorkload.java
@@ -178,6 +178,15 @@ public class AsyncCtlWorkload implements Benchmark {
         }
     }
 
+    @Override
+    public Mono<?> performSingleOperation(long operationIndex) {
+        return selectAndPerformWorkload(operationIndex)
+            .subscribeOn(benchmarkScheduler)
+            .doOnError(e -> logger.error("CTL failure on thread {}: {}",
+                Thread.currentThread().getName(), e.getMessage(), e))
+            .onErrorResume(e -> Mono.empty());
+    }
+
     public void run() throws Exception {
 
         long startTime = System.currentTimeMillis();

--- a/sdk/cosmos/azure-cosmos-benchmark/src/main/java/com/azure/cosmos/benchmark/ctl/AsyncCtlWorkload.java
+++ b/sdk/cosmos/azure-cosmos-benchmark/src/main/java/com/azure/cosmos/benchmark/ctl/AsyncCtlWorkload.java
@@ -185,22 +185,12 @@ public class AsyncCtlWorkload implements Benchmark {
 
     @Override
     public Mono<?> performSingleOperation(long operationIndex) {
-        // Intentionally omits onSuccess callback — consistent with run() which also
-        // does not track per-operation success for CTL workloads.
-        // NOTE: mirrors dispatch-wrapping pattern in AsyncBenchmark.performSingleOperation().
-        // Unlike AsyncBenchmark and AsyncEncryptionBenchmark, this class does not call
-        // onError(e) because CTL workloads have no per-operation error callback. Error
-        // counting is handled by the orchestrator's doOnError + errorCount.
-        return selectAndPerformWorkload(operationIndex)
-            .subscribeOn(benchmarkScheduler)
-            .doOnError(e -> {
-                try {
-                    logger.error("Encountered failure {} on thread {}",
-                        e.getMessage(), Thread.currentThread().getName(), e);
-                } catch (Exception handlerEx) {
-                    logger.error("Error handler threw for original error: {}", e.getMessage(), handlerEx);
-                }
-            });
+        // CTL workloads have no per-operation success/error callbacks — consistent with
+        // run() which also does not track per-operation success. Error counting is
+        // handled by the orchestrator's doOnError + errorCount.
+        return Benchmark.wrapDispatchCallbacks(
+            selectAndPerformWorkload(operationIndex).subscribeOn(benchmarkScheduler),
+            () -> { }, e -> { }, logger);
     }
 
     public void run() throws Exception {

--- a/sdk/cosmos/azure-cosmos-benchmark/src/main/java/com/azure/cosmos/benchmark/ctl/AsyncCtlWorkload.java
+++ b/sdk/cosmos/azure-cosmos-benchmark/src/main/java/com/azure/cosmos/benchmark/ctl/AsyncCtlWorkload.java
@@ -187,11 +187,11 @@ public class AsyncCtlWorkload implements Benchmark {
     public Mono<?> performSingleOperation(long operationIndex) {
         // Intentionally omits onSuccess callback — consistent with run() which also
         // does not track per-operation success for CTL workloads.
+        // NOTE: mirrors dispatch-wrapping pattern in AsyncBenchmark.performSingleOperation().
         return selectAndPerformWorkload(operationIndex)
             .subscribeOn(benchmarkScheduler)
-            .doOnError(e -> logger.error("CTL failure on thread {}: {}",
-                Thread.currentThread().getName(), e.getMessage(), e))
-            .onErrorResume(e -> Mono.empty());
+            .doOnError(e -> logger.error("Encountered failure {} on thread {}",
+                e.getMessage(), Thread.currentThread().getName(), e));
     }
 
     public void run() throws Exception {

--- a/sdk/cosmos/azure-cosmos-benchmark/src/main/java/com/azure/cosmos/benchmark/ctl/AsyncCtlWorkload.java
+++ b/sdk/cosmos/azure-cosmos-benchmark/src/main/java/com/azure/cosmos/benchmark/ctl/AsyncCtlWorkload.java
@@ -205,6 +205,10 @@ public class AsyncCtlWorkload implements Benchmark {
 
     public void run() throws Exception {
 
+        // Note: legacy run() uses System.currentTimeMillis() for deadline (wall-clock).
+        // The orchestrator dispatch path uses System.nanoTime() (monotonic) instead.
+        // This is acceptable here because standalone legacy runs are short-lived and
+        // NTP clock skew is negligible for typical benchmark durations.
         long startTime = System.currentTimeMillis();
         int concurrency = workloadConfig.getConcurrency();
 

--- a/sdk/cosmos/azure-cosmos-benchmark/src/main/java/com/azure/cosmos/benchmark/encryption/AsyncEncryptionBenchmark.java
+++ b/sdk/cosmos/azure-cosmos-benchmark/src/main/java/com/azure/cosmos/benchmark/encryption/AsyncEncryptionBenchmark.java
@@ -199,6 +199,20 @@ public abstract class AsyncEncryptionBenchmark<T> implements Benchmark {
 
     protected abstract Mono<T> performWorkload(long i);
 
+    @Override
+    public Mono<?> performSingleOperation(long operationIndex) {
+        Mono<T> workload = performWorkload(operationIndex);
+        return workload
+            .subscribeOn(benchmarkScheduler)
+            .doOnSuccess(v -> AsyncEncryptionBenchmark.this.onSuccess())
+            .doOnError(e -> {
+                logger.error("Encountered failure {} on thread {}",
+                    e.getMessage(), Thread.currentThread().getName(), e);
+                AsyncEncryptionBenchmark.this.onError(e);
+            })
+            .onErrorResume(e -> Mono.empty());
+    }
+
     @SuppressWarnings("unchecked")
     public void run() throws Exception {
 

--- a/sdk/cosmos/azure-cosmos-benchmark/src/main/java/com/azure/cosmos/benchmark/encryption/AsyncEncryptionBenchmark.java
+++ b/sdk/cosmos/azure-cosmos-benchmark/src/main/java/com/azure/cosmos/benchmark/encryption/AsyncEncryptionBenchmark.java
@@ -200,8 +200,17 @@ public abstract class AsyncEncryptionBenchmark<T> implements Benchmark {
     protected abstract Mono<T> performWorkload(long i);
 
     @Override
+    public boolean isDispatchable() {
+        return true;
+    }
+
+    @Override
     public Mono<?> performSingleOperation(long operationIndex) {
         Mono<T> workload = performWorkload(operationIndex);
+        Mono<T> delayed = sparsityMono(operationIndex);
+        if (delayed != null) {
+            workload = delayed.then(workload);
+        }
         return workload
             .subscribeOn(benchmarkScheduler)
             .doOnSuccess(v -> AsyncEncryptionBenchmark.this.onSuccess())

--- a/sdk/cosmos/azure-cosmos-benchmark/src/main/java/com/azure/cosmos/benchmark/encryption/AsyncEncryptionBenchmark.java
+++ b/sdk/cosmos/azure-cosmos-benchmark/src/main/java/com/azure/cosmos/benchmark/encryption/AsyncEncryptionBenchmark.java
@@ -217,9 +217,13 @@ public abstract class AsyncEncryptionBenchmark<T> implements Benchmark {
             .subscribeOn(benchmarkScheduler)
             .doOnSuccess(v -> AsyncEncryptionBenchmark.this.onSuccess())
             .doOnError(e -> {
-                logger.error("Encountered failure {} on thread {}",
-                    e.getMessage(), Thread.currentThread().getName(), e);
-                AsyncEncryptionBenchmark.this.onError(e);
+                try {
+                    logger.error("Encountered failure {} on thread {}",
+                        e.getMessage(), Thread.currentThread().getName(), e);
+                    AsyncEncryptionBenchmark.this.onError(e);
+                } catch (Exception handlerEx) {
+                    logger.error("onError handler threw for original error: {}", e.getMessage(), handlerEx);
+                }
             });
     }
 

--- a/sdk/cosmos/azure-cosmos-benchmark/src/main/java/com/azure/cosmos/benchmark/encryption/AsyncEncryptionBenchmark.java
+++ b/sdk/cosmos/azure-cosmos-benchmark/src/main/java/com/azure/cosmos/benchmark/encryption/AsyncEncryptionBenchmark.java
@@ -206,6 +206,8 @@ public abstract class AsyncEncryptionBenchmark<T> implements Benchmark {
 
     @Override
     public Mono<?> performSingleOperation(long operationIndex) {
+        // NOTE: This dispatch-wrapping pattern mirrors AsyncBenchmark.performSingleOperation().
+        // If modifying this logic, update AsyncBenchmark and AsyncCtlWorkload too.
         Mono<T> workload = performWorkload(operationIndex);
         Mono<T> delayed = sparsityMono(operationIndex);
         if (delayed != null) {
@@ -218,8 +220,7 @@ public abstract class AsyncEncryptionBenchmark<T> implements Benchmark {
                 logger.error("Encountered failure {} on thread {}",
                     e.getMessage(), Thread.currentThread().getName(), e);
                 AsyncEncryptionBenchmark.this.onError(e);
-            })
-            .onErrorResume(e -> Mono.empty());
+            });
     }
 
     @SuppressWarnings("unchecked")

--- a/sdk/cosmos/azure-cosmos-benchmark/src/main/java/com/azure/cosmos/benchmark/encryption/AsyncEncryptionBenchmark.java
+++ b/sdk/cosmos/azure-cosmos-benchmark/src/main/java/com/azure/cosmos/benchmark/encryption/AsyncEncryptionBenchmark.java
@@ -206,25 +206,14 @@ public abstract class AsyncEncryptionBenchmark<T> implements Benchmark {
 
     @Override
     public Mono<?> performSingleOperation(long operationIndex) {
-        // NOTE: This dispatch-wrapping pattern mirrors AsyncBenchmark.performSingleOperation().
-        // If modifying this logic, update AsyncBenchmark and AsyncCtlWorkload too.
         Mono<T> workload = performWorkload(operationIndex);
         Mono<T> delayed = sparsityMono(operationIndex);
         if (delayed != null) {
             workload = delayed.then(workload);
         }
-        return workload
-            .subscribeOn(benchmarkScheduler)
-            .doOnSuccess(v -> AsyncEncryptionBenchmark.this.onSuccess())
-            .doOnError(e -> {
-                try {
-                    logger.error("Encountered failure {} on thread {}",
-                        e.getMessage(), Thread.currentThread().getName(), e);
-                    AsyncEncryptionBenchmark.this.onError(e);
-                } catch (Exception handlerEx) {
-                    logger.error("onError handler threw for original error: {}", e.getMessage(), handlerEx);
-                }
-            });
+        return Benchmark.wrapDispatchCallbacks(
+            workload.subscribeOn(benchmarkScheduler),
+            this::onSuccess, this::onError, logger);
     }
 
     @SuppressWarnings("unchecked")

--- a/sdk/cosmos/azure-cosmos-benchmark/src/main/java/com/azure/cosmos/benchmark/linkedin/LICtlWorkload.java
+++ b/sdk/cosmos/azure-cosmos-benchmark/src/main/java/com/azure/cosmos/benchmark/linkedin/LICtlWorkload.java
@@ -66,6 +66,11 @@ public class LICtlWorkload implements Benchmark {
         _testRunner.run();
     }
 
+    @Override
+    public boolean isDispatchable() {
+        return false;
+    }
+
     public void shutdown() {
         _testRunner.cleanup();
         if (_workloadConfig.isSuppressCleanup()) {

--- a/sdk/cosmos/azure-cosmos-benchmark/src/test/java/com/azure/cosmos/benchmark/BenchmarkConfigTest.java
+++ b/sdk/cosmos/azure-cosmos-benchmark/src/test/java/com/azure/cosmos/benchmark/BenchmarkConfigTest.java
@@ -1,0 +1,92 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package com.azure.cosmos.benchmark;
+
+import org.testng.annotations.Test;
+
+import java.io.File;
+import java.io.FileWriter;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Unit tests for {@link BenchmarkConfig} dispatch configuration validation.
+ * These tests do not require a Cosmos DB connection.
+ */
+public class BenchmarkConfigTest {
+
+    @Test(groups = "unit")
+    public void maxRunningTimeDuration_zeroDuration_throwsIllegalArgument() throws Exception {
+        File configFile = createConfigFile("{ \"maxRunningTimeDuration\": \"PT0S\", \"tenants\": [] }");
+        try {
+            BenchmarkConfig config = new BenchmarkConfig();
+            assertThatThrownBy(() -> config.loadDispatchConfigFromFile(configFile))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("must be positive");
+        } finally {
+            configFile.delete();
+        }
+    }
+
+    @Test(groups = "unit")
+    public void maxRunningTimeDuration_negativeDuration_throwsIllegalArgument() throws Exception {
+        File configFile = createConfigFile("{ \"maxRunningTimeDuration\": \"-PT10S\", \"tenants\": [] }");
+        try {
+            BenchmarkConfig config = new BenchmarkConfig();
+            assertThatThrownBy(() -> config.loadDispatchConfigFromFile(configFile))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("must be positive");
+        } finally {
+            configFile.delete();
+        }
+    }
+
+    @Test(groups = "unit")
+    public void maxRunningTimeDuration_malformedDuration_throwsIllegalArgument() throws Exception {
+        File configFile = createConfigFile("{ \"maxRunningTimeDuration\": \"notADuration\", \"tenants\": [] }");
+        try {
+            BenchmarkConfig config = new BenchmarkConfig();
+            assertThatThrownBy(() -> config.loadDispatchConfigFromFile(configFile))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("not a valid ISO-8601 duration");
+        } finally {
+            configFile.delete();
+        }
+    }
+
+    @Test(groups = "unit")
+    public void maxRunningTimeDuration_validDuration_parsesSuccessfully() throws Exception {
+        File configFile = createConfigFile("{ \"maxRunningTimeDuration\": \"PT30S\", \"tenants\": [] }");
+        try {
+            BenchmarkConfig config = new BenchmarkConfig();
+            config.loadDispatchConfigFromFile(configFile);
+            assertThat(config.getMaxRunningTimeDuration()).isEqualTo("PT30S");
+            assertThat(config.getMaxRunningTimeDurationParsed()).isEqualTo(java.time.Duration.ofSeconds(30));
+        } finally {
+            configFile.delete();
+        }
+    }
+
+    @Test(groups = "unit")
+    public void concurrency_zeroConcurrency_throwsIllegalArgument() throws Exception {
+        File configFile = createConfigFile("{ \"concurrency\": 0, \"tenants\": [] }");
+        try {
+            BenchmarkConfig config = new BenchmarkConfig();
+            assertThatThrownBy(() -> config.loadDispatchConfigFromFile(configFile))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("concurrency must be a positive integer");
+        } finally {
+            configFile.delete();
+        }
+    }
+
+    private File createConfigFile(String json) throws Exception {
+        File tempFile = File.createTempFile("benchmark-config-test-", ".json");
+        try (FileWriter writer = new FileWriter(tempFile)) {
+            writer.write(json);
+        }
+        return tempFile;
+    }
+}

--- a/sdk/cosmos/azure-cosmos-benchmark/src/test/java/com/azure/cosmos/benchmark/BenchmarkConfigTest.java
+++ b/sdk/cosmos/azure-cosmos-benchmark/src/test/java/com/azure/cosmos/benchmark/BenchmarkConfigTest.java
@@ -83,6 +83,19 @@ public class BenchmarkConfigTest {
     }
 
     @Test(groups = "unit")
+    public void concurrency_negativeConcurrency_throwsIllegalArgument() throws Exception {
+        File configFile = createConfigFile("{ \"concurrency\": -1, \"tenants\": [] }");
+        try {
+            BenchmarkConfig config = new BenchmarkConfig();
+            assertThatThrownBy(() -> config.loadDispatchConfigFromFile(configFile))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("concurrency must be a positive integer");
+        } finally {
+            configFile.delete();
+        }
+    }
+
+    @Test(groups = "unit")
     public void numberOfOperations_zeroOperations_throwsIllegalArgument() throws Exception {
         File configFile = createConfigFile("{ \"numberOfOperations\": 0, \"tenants\": [] }");
         try {
@@ -110,6 +123,7 @@ public class BenchmarkConfigTest {
 
     private File createConfigFile(String json) throws Exception {
         File tempFile = File.createTempFile("benchmark-config-test-", ".json");
+        tempFile.deleteOnExit();
         try (FileWriter writer = new FileWriter(tempFile)) {
             writer.write(json);
         }

--- a/sdk/cosmos/azure-cosmos-benchmark/src/test/java/com/azure/cosmos/benchmark/BenchmarkConfigTest.java
+++ b/sdk/cosmos/azure-cosmos-benchmark/src/test/java/com/azure/cosmos/benchmark/BenchmarkConfigTest.java
@@ -82,6 +82,32 @@ public class BenchmarkConfigTest {
         }
     }
 
+    @Test(groups = "unit")
+    public void numberOfOperations_zeroOperations_throwsIllegalArgument() throws Exception {
+        File configFile = createConfigFile("{ \"numberOfOperations\": 0, \"tenants\": [] }");
+        try {
+            BenchmarkConfig config = new BenchmarkConfig();
+            assertThatThrownBy(() -> config.loadDispatchConfigFromFile(configFile))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("numberOfOperations must be a positive integer");
+        } finally {
+            configFile.delete();
+        }
+    }
+
+    @Test(groups = "unit")
+    public void numberOfOperations_negativeOperations_throwsIllegalArgument() throws Exception {
+        File configFile = createConfigFile("{ \"numberOfOperations\": -5, \"tenants\": [] }");
+        try {
+            BenchmarkConfig config = new BenchmarkConfig();
+            assertThatThrownBy(() -> config.loadDispatchConfigFromFile(configFile))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("numberOfOperations must be a positive integer");
+        } finally {
+            configFile.delete();
+        }
+    }
+
     private File createConfigFile(String json) throws Exception {
         File tempFile = File.createTempFile("benchmark-config-test-", ".json");
         try (FileWriter writer = new FileWriter(tempFile)) {

--- a/sdk/cosmos/azure-cosmos-benchmark/src/test/java/com/azure/cosmos/benchmark/WorkflowTest.java
+++ b/sdk/cosmos/azure-cosmos-benchmark/src/test/java/com/azure/cosmos/benchmark/WorkflowTest.java
@@ -315,6 +315,11 @@ public class WorkflowTest {
         int numberOfOperations,
         int numberOfPreCreatedDocuments) throws Exception {
 
+        // concurrency and numberOfOperations are set at the orchestrator level only.
+        // Tenant-level concurrency/numberOfOperations are intentionally left to their defaults
+        // because orchestrator dispatch mode ignores per-tenant values. The SyncBenchmark
+        // concurrencyControlSemaphore uses the tenant's getConcurrency() (default 1000),
+        // which is fine since the orchestrator's flatMap concurrency controls actual parallelism.
         String json = String.format(
             "{ \"concurrency\": %d, \"numberOfOperations\": %d, "
                 + "\"tenants\": [{ "

--- a/sdk/cosmos/azure-cosmos-benchmark/src/test/java/com/azure/cosmos/benchmark/WorkflowTest.java
+++ b/sdk/cosmos/azure-cosmos-benchmark/src/test/java/com/azure/cosmos/benchmark/WorkflowTest.java
@@ -316,7 +316,8 @@ public class WorkflowTest {
         int numberOfPreCreatedDocuments) throws Exception {
 
         String json = String.format(
-            "{ \"tenants\": [{ "
+            "{ \"concurrency\": %d, \"numberOfOperations\": %d, "
+                + "\"tenants\": [{ "
                 + "\"serviceEndpoint\": \"%s\", "
                 + "\"masterKey\": \"%s\", "
                 + "\"databaseId\": \"%s\", "
@@ -324,13 +325,12 @@ public class WorkflowTest {
                 + "\"operation\": \"%s\", "
                 + "\"connectionMode\": \"%s\", "
                 + "\"consistencyLevel\": \"%s\", "
-                + "\"concurrency\": %d, "
-                + "\"numberOfOperations\": %d, "
                 + "\"numberOfPreCreatedDocuments\": %d "
                 + "}] }",
+            concurrency, numberOfOperations,
             serviceEndpoint, masterKey, databaseId, containerId,
             operation, connectionMode, consistencyLevel,
-            concurrency, numberOfOperations, numberOfPreCreatedDocuments);
+            numberOfPreCreatedDocuments);
 
         File tempFile = File.createTempFile("workload-config-", ".json");
         try (FileWriter writer = new FileWriter(tempFile)) {


### PR DESCRIPTION
## Move benchmark dispatch from per-tenant to orchestrator level

This PR refactors the benchmark dispatch logic from per-tenant level to the orchestrator level for cleaner architecture and better control flow.

### Changes
- **BenchmarkOrchestrator**: Centralized dispatch logic with proper thread pool management, failure propagation, and graceful shutdown
- **AsyncBenchmark/SyncBenchmark**: Added dispatch callback support for orchestrator-level coordination
- **BenchmarkConfig**: Added configuration validation (Duration, concurrency), sync pool size, and dispatch parameters
- **Error handling**: Improved error observability with volatile flags, proper semaphore release, and failure propagation
- **Tests**: Added BenchmarkConfigTest with validation coverage, updated WorkflowTest

### Review Summary
- 7 automated review iterations with 55+ fixes applied
- 0 critical issues remaining
- All fixes address: resource leaks, thread safety, validation, error handling, and observability

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>