### PR TITLE
Fix 400/1024 error when container is re-created with same name

### DIFF
--- a/sdk/cosmos/azure-cosmos-tests/src/test/java/com/azure/cosmos/implementation/StaleResourceExceptionRetryPolicyTest.java
+++ b/sdk/cosmos/azure-cosmos-tests/src/test/java/com/azure/cosmos/implementation/StaleResourceExceptionRetryPolicyTest.java
@@ -98,6 +98,76 @@ public class StaleResourceExceptionRetryPolicyTest {
         assertThat(shouldRetryResult.shouldRetry).isFalse();
     }
 
+    @DataProvider(name = "staleContainerExceptionProvider")
+    public Object[][] staleContainerExceptionProvider() {
+        return new Object[][] {
+            //status code, subStatusCode
+            { HttpConstants.StatusCodes.GONE, HttpConstants.SubStatusCodes.NAME_CACHE_IS_STALE },
+            { HttpConstants.StatusCodes.BADREQUEST, HttpConstants.SubStatusCodes.INCORRECT_CONTAINER_RID_SUB_STATUS },
+        };
+    }
+
+    @Test(groups = "unit", dataProvider = "staleContainerExceptionProvider")
+    public void requestContextResetOnRetry(int statusCode, int subStatusCode) {
+        // Validates that when StaleResourceRetryPolicy retries a stale-container
+        // exception, it resets the request context so the retry re-resolves the
+        // collection and sends the updated intended-collection-rid header.
+        String testCollectionLink = "/dbs/test/colls/contextResetTest";
+
+        DocumentCollection documentCollection = new DocumentCollection();
+        documentCollection.setId("contextResetTest");
+        documentCollection.setResourceId("oldRid");
+
+        DocumentCollection documentCollectionAfterRefresh = new DocumentCollection();
+        documentCollectionAfterRefresh.setId("contextResetTest");
+        documentCollectionAfterRefresh.setResourceId("newRid");
+
+        RxCollectionCache rxCollectionCache = Mockito.mock(RxCollectionCache.class);
+        Mockito
+            .when(rxCollectionCache.resolveByNameAsync(Mockito.any(), Mockito.any(), Mockito.isNull(), Mockito.isNull(), Mockito.isNull()))
+            .thenReturn(Mono.just(documentCollection))
+            .thenReturn(Mono.just(documentCollectionAfterRefresh));
+        doNothing().when(rxCollectionCache).refresh(Mockito.any(), Mockito.any(), Mockito.isNull());
+
+        ISessionContainer sessionContainer = Mockito.mock(ISessionContainer.class);
+        doNothing().when(sessionContainer).clearTokenByResourceId(documentCollection.getResourceId());
+
+        StaleResourceRetryPolicy staleResourceRetryPolicy = new StaleResourceRetryPolicy(
+            rxCollectionCache,
+            null,
+            testCollectionLink,
+            null,
+            null,
+            sessionContainer,
+            TestUtils.mockDiagnosticsClientContext(),
+            null
+        );
+
+        // Simulate a request with a stale resolvedCollectionRid and intended header
+        RxDocumentServiceRequest request = RxDocumentServiceRequest.createFromName(
+            TestUtils.mockDiagnosticsClientContext(),
+            OperationType.Read, "/dbs/test/colls/contextResetTest/docs/doc1", ResourceType.Document);
+        request.requestContext = new DocumentServiceRequestContext();
+        request.requestContext.resolvedCollectionRid = "oldRid";
+        request.getHeaders().put(HttpConstants.HttpHeaders.INTENDED_COLLECTION_RID_HEADER, "oldRid");
+
+        staleResourceRetryPolicy.onBeforeSendRequest(request);
+
+        CosmosException exception = BridgeInternal.createCosmosException(statusCode);
+        BridgeInternal.setSubStatusCode(exception, subStatusCode);
+
+        ShouldRetryResult shouldRetryResult = staleResourceRetryPolicy.shouldRetry(exception).block();
+        assertThat(shouldRetryResult.shouldRetry).isTrue();
+
+        // Verify request context was reset for a clean retry
+        assertThat(request.requestContext.resolvedCollectionRid).isNull();
+        assertThat(request.forceNameCacheRefresh).isTrue();
+        assertThat(request.getHeaders().get(HttpConstants.HttpHeaders.INTENDED_COLLECTION_RID_HEADER)).isNull();
+
+        // Verify session token was cleaned up for the old rid
+        verify(sessionContainer, Mockito.times(1)).clearTokenByResourceId("oldRid");
+    }
+
     @Test(groups = "unit")
     public void cleanSessionToken() {
         String testCollectionLink = "/dbs/test/colls/staledExceptionTest";

--- a/sdk/cosmos/azure-cosmos/src/main/java/com/azure/cosmos/implementation/StaleResourceRetryPolicy.java
+++ b/sdk/cosmos/azure-cosmos/src/main/java/com/azure/cosmos/implementation/StaleResourceRetryPolicy.java
@@ -124,6 +124,14 @@ public class StaleResourceRetryPolicy extends DocumentClientRetryPolicy {
                             this.sessionContainer.clearTokenByResourceId(oldCollectionRid.get());
                         }
 
+                        // Reset request context so the retry re-resolves the collection
+                        // and sends the updated intended-collection-rid header.
+                        if (this.request != null) {
+                            this.request.forceNameCacheRefresh = true;
+                            this.request.requestContext.resolvedCollectionRid = null;
+                            this.request.getHeaders().remove(HttpConstants.HttpHeaders.INTENDED_COLLECTION_RID_HEADER);
+                        }
+
                         this.retried = true;
                         if (this.shouldSuppressRetry.get()) {
                             return Mono.just(ShouldRetryResult.error(e));


### PR DESCRIPTION
## Problem

When a container is deleted and re-created with the same name, subsequent read/write/query operations fail with:
```
com.azure.cosmos.CosmosException: {"innerErrorMessage":"{\"Errors\":[\"Collection rid provided by the user does not match the existing collection.\"]}, StatusCode: BadRequest"}
```
(HTTP 400, sub-status 1024 / INCORRECT_CONTAINER_RID_SUB_STATUS)

This affects gateway mode because the stale intended-collection-rid header persists through retry.

## Root Cause

`StaleResourceRetryPolicy` correctly handles 400/1024 by refreshing the collection cache and clearing session tokens, but it did **not** reset the request context before the retry:

1. `request.requestContext.resolvedCollectionRid` still held the old collection RID
2. `request.forceNameCacheRefresh` was still `false`
3. The `x-ms-cosmos-intended-collection-rid` HTTP header still carried the old RID

On retry, `RxGatewayStoreModel.addIntendedCollectionRid()` checks if the header is already set and skips updating it — so the stale RID is sent again, causing the same 400/1024 error.

## Fix

After refreshing the collection cache in `StaleResourceRetryPolicy.shouldRetry()`, reset:
- `resolvedCollectionRid` → `null`
- `forceNameCacheRefresh` → `true`
- Remove the `INTENDED_COLLECTION_RID_HEADER`

This ensures the retry re-resolves the collection and sends the correct (new) RID.

## Testing

Added parameterized unit test `requestContextResetOnRetry` covering both error codes:
- 410/1000 (NAME_CACHE_IS_STALE — direct mode)
- 400/1024 (INCORRECT_CONTAINER_RID_SUB_STATUS — gateway mode)

The test verifies that after `shouldRetry()`:
- `resolvedCollectionRid` is cleared to `null`
- `forceNameCacheRefresh` is set to `true`
- `INTENDED_COLLECTION_RID_HEADER` is removed
- Old session tokens are cleaned up

Fixes Azure/azure-sdk-for-java#49097